### PR TITLE
Preserve annotations from initial FIRRTL pass

### DIFF
--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -235,6 +235,9 @@ object TreadleExecutive {
         firrtlExecutionResult match {
           case success: FirrtlExecutionSuccess =>
             val dut = getTopModule(circuit).asInstanceOf[T]
+            optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(
+              annotations = success.circuitState.annotations.toSeq.toList
+            )
             val interpretiveTester = new TreadleTester(success.emitted, optionsManager)
 
             val portNames = DataMirror.modulePorts(dut).flatMap { case (name, data) =>


### PR DESCRIPTION
This PR fixes an issue where new/updated annotations from the [initial compiler pass](https://github.com/ucb-bar/chisel-testers2/blob/master/src/main/scala/chisel3/tester/TreadleBackend.scala#L233) are not passed to the [following lowering pass](https://github.com/freechipsproject/treadle/blob/master/src/main/scala/treadle/executable/ExecutionEngine.scala#L430).

Related: https://github.com/freechipsproject/chisel3/issues/968