### PR TITLE
Regions

### DIFF
--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -16,6 +16,21 @@ trait AbstractTesterThread {
 
 }
 
+/** Base class for regions, akin to Verilog regions for ordering events between threads within the same timestep.
+  * order is the order regions run in, with 0 being the default, and incrementing regions running later.
+  * TODO: have a more extensible ordering than ints.
+  */
+sealed class Region(val order: Int)
+
+object Region {
+  val allRegions = Seq(DefaultRegion, Monitor)
+}
+
+// Testdriver starts in this. Not to be specified in user code
+object DefaultRegion extends Region(0)
+object Monitor extends Region(1)
+
+
 class TesterThreadList(protected val elts: Seq[AbstractTesterThread]) {
   def toSeq(): Seq[AbstractTesterThread] = elts
 
@@ -66,6 +81,8 @@ trait BackendInterface {
   def doJoin(thread: AbstractTesterThread): Unit
 
   def doTimescope(contents: () => Unit): Unit
+
+  def doRegion(region: Region, contents: () => Unit): Unit
 
   protected val testMap = mutable.HashMap[Any, Any]()
 

--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -11,10 +11,10 @@ import firrtl.ExecutionOptionsManager
 class ThreadOrderDependentException(message: String) extends Exception(message)
 class TimeoutException(message: String) extends Exception(message)
 
+// when interfacing with the testdriver before stepping the clock after moving to an earlier region
+class TemporalParadox(message: String) extends Exception(message)
 
-trait AbstractTesterThread {
-
-}
+trait AbstractTesterThread
 
 /** Base class for regions, akin to Verilog regions for ordering events between threads within the same timestep.
   * order is the order regions run in, with 0 being the default, and incrementing regions running later.

--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -20,15 +20,25 @@ trait AbstractTesterThread
   * order is the order regions run in, with 0 being the default, and incrementing regions running later.
   * TODO: have a more extensible ordering than ints.
   */
-sealed class Region(val order: Int)
+sealed class Region {
+  protected def getPos(): Int = {
+    val pos = Region.allRegions.indexOf(this)
+    require(pos >= 0)
+    pos
+  }
+
+  def isBefore(other: Region): Boolean = this.getPos < other.getPos
+  def isAfter(other: Region): Boolean = this.getPos > other.getPos
+  def isEqual(other: Region): Boolean = this.getPos == other.getPos
+}
 
 object Region {
   val allRegions = Seq(DefaultRegion, Monitor)
 }
 
 // Testdriver starts in this. Not to be specified in user code
-object DefaultRegion extends Region(0)
-object Monitor extends Region(1)
+object DefaultRegion extends Region
+object Monitor extends Region
 
 
 class TesterThreadList(protected val elts: Seq[AbstractTesterThread]) {

--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -33,11 +33,12 @@ sealed class Region {
 }
 
 object Region {
-  val allRegions = Seq(DefaultRegion, Monitor)
+  val default = TestdriverMain
+  val allRegions = Seq(default, Monitor)
 }
 
 // Testdriver starts in this. Not to be specified in user code
-object DefaultRegion extends Region
+object TestdriverMain extends Region
 object Monitor extends Region
 
 

--- a/src/main/scala/chisel3/tester/DecoupledDriver.scala
+++ b/src/main/scala/chisel3/tester/DecoupledDriver.scala
@@ -34,8 +34,10 @@ class DecoupledDriver[T <: Data](x: DecoupledIO[T]) {
     // TODO: check for init
     x.bits.poke(data)
     x.valid.poke(true.B)
-    while (x.ready.peek().litToBoolean == false) {
-      getSourceClock.step(1)
+    region(Monitor) {
+      while (x.ready.peek().litToBoolean == false) {
+        getSourceClock.step(1)
+      }
     }
     getSourceClock.step(1)
   }
@@ -70,16 +72,28 @@ class DecoupledDriver[T <: Data](x: DecoupledIO[T]) {
   def expectDequeue(data: T): Unit = timescope {
     // TODO: check for init
     x.ready.poke(true.B)
-    waitForValid()
-    expectDequeueNow(data)
+    region(Monitor) {
+      waitForValid()
+      x.valid.expect(true.B)
+      x.bits.expect(data)
+    }
+    getSinkClock.step(1)
   }
 
   def expectDequeueNow(data: T): Unit = timescope {
     // TODO: check for init
     x.ready.poke(true.B)
-    x.valid.expect(true.B)
-    x.bits.expect(data)
+    region(Monitor) {
+      x.valid.expect(true.B)
+      x.bits.expect(data)
+    }
     getSinkClock.step(1)
+  }
+
+  def expectDequeueSeq(data: Seq[T]): Unit = timescope {
+    for (elt <- data) {
+      expectDequeue(elt)
+    }
   }
 
   def expectPeek(data: T): Unit = {

--- a/src/main/scala/chisel3/tester/ThreadedBackend.scala
+++ b/src/main/scala/chisel3/tester/ThreadedBackend.scala
@@ -364,6 +364,11 @@ trait ThreadedBackend {
     // TODO: check that lastTimescope signal is actually the one effective?
   }
 
+  def doRegion(region: Region, contents: () => Unit): Unit = {
+    require(Region.allRegions.contains(region))
+    contents()
+  }
+
   protected val interruptedException = new ConcurrentLinkedQueue[Throwable]()
   /**
    * Called when an exception happens inside a thread.

--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -129,7 +129,7 @@ class TreadleBackend[T <: MultiIOModule](dut: T,
         tester.poke("reset", 0)
 
         testFn(dut)
-      }, 0, rootTimescope.get, 0)
+      }, TimeRegion(0, Region.default), rootTimescope.get, 0)
     mainThread.thread.start()
     require(allThreads.isEmpty)
     allThreads += mainThread

--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -136,7 +136,6 @@ class TreadleBackend[T <: MultiIOModule](dut: T,
 
     while (!mainThread.done) {  // iterate timesteps
       clockCounter.put(dut.clock, getClockCycle(dut.clock) + 1)
-      currentTimestep += 1
 
       debugLog(s"clock step")
 
@@ -154,8 +153,6 @@ class TreadleBackend[T <: MultiIOModule](dut: T,
       }
 
       runThreads(steppedClocks.toSet)
-
-      timestep()
       Context().env.checkpoint()
 
       idleLimits foreach { case (clock, limit) =>

--- a/src/main/scala/chisel3/tester/package.scala
+++ b/src/main/scala/chisel3/tester/package.scala
@@ -120,6 +120,10 @@ package object tester {
     Context().backend.doTimescope(() => contents)
   }
 
+  def region(region: Region)(contents: => Unit): Unit = {
+    Context().backend.doRegion(region, () => contents)
+  }
+
   object TestInstance {
     def setVar(key: Any, value: Any): Unit = {
       Context().backend.setVar(key, value)

--- a/src/test/scala/chisel3/tests/QueueTest.scala
+++ b/src/test/scala/chisel3/tests/QueueTest.scala
@@ -47,4 +47,19 @@ class QueueTest extends FlatSpec with ChiselScalatestTester {
       c.out.expectInvalid()
     }
   }
+
+  it should "work with a combinational queue" in {
+    test(new PassthroughQueue(UInt(8.W))) { c =>
+      c.in.initSource()
+      c.in.setSourceClock(c.clock)
+      c.out.initSink()
+      c.out.setSinkClock(c.clock)
+
+      fork {
+        c.in.enqueueSeq(Seq(42.U, 43.U, 44.U))
+      }.fork {
+        c.out.expectDequeueSeq(Seq(42.U, 43.U, 44.U))
+      }.join()
+    }
+  }
 }

--- a/src/test/scala/chisel3/tests/RegionsTest.scala
+++ b/src/test/scala/chisel3/tests/RegionsTest.scala
@@ -41,4 +41,14 @@ class RegionsTest extends FlatSpec with ChiselScalatestTester {
       }.join()
     }
   }
+
+  it should "not allow simulator interaction between moving to an earlier region and stepping the clock" in {
+    assertThrows[TemporalParadox] {
+      test(new StaticModule(42.U)) { c =>
+        region(Monitor) {
+        }
+        c.out.expect(0.U)
+      }
+    }
+  }
 }

--- a/src/test/scala/chisel3/tests/RegionsTest.scala
+++ b/src/test/scala/chisel3/tests/RegionsTest.scala
@@ -21,7 +21,6 @@ class RegionsTest extends FlatSpec with ChiselScalatestTester {
           c.clock.step()
           c.in.expect(70.U)
         }
-        c.clock.step()
       }.join()
     }
   }
@@ -34,7 +33,6 @@ class RegionsTest extends FlatSpec with ChiselScalatestTester {
           c.clock.step()
           c.in.expect(70.U)
         }
-        c.clock.step()
       }.fork {
         c.in.poke(42.U)
         c.clock.step()
@@ -44,12 +42,53 @@ class RegionsTest extends FlatSpec with ChiselScalatestTester {
     }
   }
 
-  it should "not allow simulator interaction between moving to an earlier region and stepping the clock" in {
+  it should "not allow joining from a later region" in {
+    assertThrows[TemporalParadox] {
+      test(new PassthroughModule(UInt(8.W))) { c =>
+        // No one should actually write this kind of code, this is whitebox testing of an edge case
+        var laterThread: Option[TesterThreadList] = None
+        region(Monitor) {
+          laterThread = Some(fork {
+            c.clock.step()
+          })
+        }
+        laterThread.get.join()
+      }
+    }
+  }
+
+  it should "allow joining from an earlier region" in {
+    test(new ShifterModule(UInt(8.W))) { c =>
+      // No one should actually write this kind of code, this is whitebox testing of an edge case
+      val thread = fork {
+        c.in.poke(42.U)
+        c.clock.step()
+      }
+      region(Monitor) {
+        thread.join()
+        c.out.expect(42.U)
+      }
+    }
+  }
+
+  it should "not allow simulator interaction between moving to an earlier region and stepping the clock, for expect" in {
     assertThrows[TemporalParadox] {
       test(new StaticModule(42.U)) { c =>
         region(Monitor) {
         }
         c.out.expect(0.U)
+      }
+    }
+  }
+
+  it should "not allow simulator interaction between moving to an earlier region and stepping the clock, for timescope revert" in {
+    assertThrows[TemporalParadox] {
+      test(new PassthroughModule(Bool())) { c =>
+        timescope {
+          c.in.poke(true.B)
+          region(Monitor) {
+          }
+        }
       }
     }
   }

--- a/src/test/scala/chisel3/tests/RegionsTest.scala
+++ b/src/test/scala/chisel3/tests/RegionsTest.scala
@@ -1,0 +1,44 @@
+package chisel3.tests
+
+import org.scalatest._
+
+import chisel3._
+import chisel3.tester._
+
+class RegionsTest extends FlatSpec with ChiselScalatestTester {
+  behavior of "Testers2 Regions"
+
+  it should "resolve read-after-write dependencies" in {
+    test(new PassthroughModule(UInt(8.W))) { c =>
+      fork {
+        c.in.poke(42.U)
+        c.clock.step()
+        c.in.poke(70.U)
+        c.clock.step()
+      }.fork {
+        region(Monitor) {
+          c.in.expect(42.U)
+          c.clock.step()
+          c.in.expect(70.U)
+        }
+      }.join()
+    }
+  }
+
+  it should "resolve read-after-write dependencies, even if threads in opposite order" in {
+    test(new PassthroughModule(UInt(8.W))) { c =>
+      fork {
+        region(Monitor) {
+          c.in.expect(42.U)
+          c.clock.step()
+          c.in.expect(70.U)
+        }
+      }.fork {
+        c.in.poke(42.U)
+        c.clock.step()
+        c.in.poke(70.U)
+        c.clock.step()
+      }.join()
+    }
+  }
+}

--- a/src/test/scala/chisel3/tests/RegionsTest.scala
+++ b/src/test/scala/chisel3/tests/RegionsTest.scala
@@ -21,6 +21,7 @@ class RegionsTest extends FlatSpec with ChiselScalatestTester {
           c.clock.step()
           c.in.expect(70.U)
         }
+        c.clock.step()
       }.join()
     }
   }
@@ -33,6 +34,7 @@ class RegionsTest extends FlatSpec with ChiselScalatestTester {
           c.clock.step()
           c.in.expect(70.U)
         }
+        c.clock.step()
       }.fork {
         c.in.poke(42.U)
         c.clock.step()


### PR DESCRIPTION
Adds support for regions, which is a way to subdivide timeslots (atomic increments in simulator time) to allow combinational operations between threads to be resolved deterministically. This enables a passthrough decoupled interface to be driven using the DecoupledDriver abstraction.

This has `region(...)` as a blocking interface, which must be followed by a clock step if moving backwards. An alternative would be to have threads associated with an immutable region. To be discussed, as it would have a different set of tradeoffs, but this is being pushed for now.

Resolves #3 