### PR TITLE
Fork with Regions

### DIFF
--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -53,9 +53,7 @@ class TesterThreadList(protected val elts: Seq[AbstractTesterThread]) {
     new TesterThreadList(elts ++ others.elts)
   }
 
-  def fork(runnable: => Unit): TesterThreadList = {
-    new TesterThreadList(elts :+ Context().backend.doFork(() => runnable))
-  }
+  val fork: ForkBuilder = new ForkBuilder(None, None, elts)
 }
 
 /** Common interface definition for tester backends. Internal API.
@@ -87,13 +85,11 @@ trait BackendInterface {
     */
   def step(signal: Clock, cycles: Int): Unit
 
-  def doFork(runnable: () => Unit): AbstractTesterThread
+  def doFork(runnable: () => Unit, name: Option[String], region: Option[Region]): AbstractTesterThread
 
   def doJoin(thread: AbstractTesterThread): Unit
 
   def doTimescope(contents: () => Unit): Unit
-
-  def doRegion(region: Region, contents: () => Unit): Unit
 
   protected val testMap = mutable.HashMap[Any, Any]()
 

--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -46,7 +46,11 @@ class TesterThreadList(protected val elts: Seq[AbstractTesterThread]) {
   def toSeq(): Seq[AbstractTesterThread] = elts
 
   def join() {
-    elts foreach { thread => Context().backend.doJoin(thread) }
+    Context().backend.doJoin(elts, None)
+  }
+
+  def joinAndStep(clock: Clock) {
+    Context().backend.doJoin(elts, Some(clock))
   }
 
   def ++(others: TesterThreadList): TesterThreadList = {
@@ -87,7 +91,7 @@ trait BackendInterface {
 
   def doFork(runnable: () => Unit, name: Option[String], region: Option[Region]): AbstractTesterThread
 
-  def doJoin(thread: AbstractTesterThread): Unit
+  def doJoin(threads: Seq[AbstractTesterThread], stepAfter: Option[Clock]): Unit
 
   def doTimescope(contents: () => Unit): Unit
 

--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -95,6 +95,12 @@ trait BackendInterface {
 
   def doTimescope(contents: () => Unit): Unit
 
+  /** Returns the stack trace elements of parent threads. If currently in the root thread, returns
+    * empty.
+    * TODO: refactor this, figure out how to do this in a structurally cleaner way
+    */
+  def getParentTraceElements: Seq[StackTraceElement] = Seq()
+
   protected val testMap = mutable.HashMap[Any, Any]()
 
   /** Sets the value associated with a key in a per-test map.

--- a/src/main/scala/chisel3/tester/DecoupledDriver.scala
+++ b/src/main/scala/chisel3/tester/DecoupledDriver.scala
@@ -34,12 +34,11 @@ class DecoupledDriver[T <: Data](x: DecoupledIO[T]) {
     // TODO: check for init
     x.bits.poke(data)
     x.valid.poke(true.B)
-    region(Monitor) {
+    fork.withRegion(Monitor) {
       while (x.ready.peek().litToBoolean == false) {
         getSourceClock.step(1)
       }
-    }
-    getSourceClock.step(1)
+    }.joinAndStep(getSourceClock)
   }
 
   def enqueueSeq(data: Seq[T]): Unit = timescope {
@@ -72,22 +71,20 @@ class DecoupledDriver[T <: Data](x: DecoupledIO[T]) {
   def expectDequeue(data: T): Unit = timescope {
     // TODO: check for init
     x.ready.poke(true.B)
-    region(Monitor) {
+    fork.withRegion(Monitor) {
       waitForValid()
       x.valid.expect(true.B)
       x.bits.expect(data)
-    }
-    getSinkClock.step(1)
+    }.joinAndStep(getSinkClock)
   }
 
   def expectDequeueNow(data: T): Unit = timescope {
     // TODO: check for init
     x.ready.poke(true.B)
-    region(Monitor) {
+    fork.withRegion(Monitor) {
       x.valid.expect(true.B)
       x.bits.expect(data)
-    }
-    getSinkClock.step(1)
+    }.joinAndStep(getSinkClock)
   }
 
   def expectDequeueSeq(data: Seq[T]): Unit = timescope {

--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -129,7 +129,7 @@ class TreadleBackend[T <: MultiIOModule](dut: T,
         tester.poke("reset", 0)
 
         testFn(dut)
-      }, TimeRegion(0, Region.default), rootTimescope.get, 0, Region.default)
+      }, TimeRegion(0, Region.default), rootTimescope.get, 0, Region.default, None)
     mainThread.thread.start()
     require(allThreads.isEmpty)
     allThreads += mainThread

--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -129,7 +129,7 @@ class TreadleBackend[T <: MultiIOModule](dut: T,
         tester.poke("reset", 0)
 
         testFn(dut)
-      }, TimeRegion(0, Region.default), rootTimescope.get, 0)
+      }, TimeRegion(0, Region.default), rootTimescope.get, 0, Region.default)
     mainThread.thread.start()
     require(allThreads.isEmpty)
     allThreads += mainThread

--- a/src/main/scala/chisel3/tester/package.scala
+++ b/src/main/scala/chisel3/tester/package.scala
@@ -105,8 +105,21 @@ package object tester {
     }
   }
 
-  def fork(runnable: => Unit): TesterThreadList = {
-    new TesterThreadList(Seq(Context().backend.doFork(() => runnable)))
+  object fork extends ForkBuilder(None, None, Seq())
+
+  case class ForkBuilder(name: Option[String], region: Option[Region], threads: Seq[AbstractTesterThread]) {
+    def apply(runnable: => Unit): TesterThreadList = {
+      new TesterThreadList(threads ++ Seq(Context().backend.doFork(() => runnable, name, region)))
+    }
+
+    def withRegion(newRegion: Region): ForkBuilder = {
+      require(region.isEmpty)
+      this.copy(region=Some(newRegion))
+    }
+    def withName(newName: String): ForkBuilder = {
+      require(name.isEmpty)
+      this.copy(name=Some(newName))
+    }
   }
 
   // TODO: call-by-name doesn't work with varargs, is there a better way to do this?
@@ -118,10 +131,6 @@ package object tester {
 
   def timescope(contents: => Unit): Unit = {
     Context().backend.doTimescope(() => contents)
-  }
-
-  def region(region: Region)(contents: => Unit): Unit = {
-    Context().backend.doRegion(region, () => contents)
   }
 
   object TestInstance {

--- a/src/test/scala/chisel3/tests/FaultLocatorTest.scala
+++ b/src/test/scala/chisel3/tests/FaultLocatorTest.scala
@@ -16,6 +16,18 @@ class FaultLocatorTest extends FlatSpec with ChiselScalatestTester with Matchers
     }.failedCodeFileNameAndLineNumberString.get should equal ("FaultLocatorTest.scala:14")
   }
 
+  it should "locate source lines across threads" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule(42.U)) { c =>
+        fork {
+          c.clock.step()
+          c.out.expect(0.U)
+        }.join()
+      }
+    }
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*22.*\)""")
+  }
+
   it should "locate source lines in libraries" in {
     val exc = intercept[exceptions.TestFailedException] {
       test(new PassthroughQueue(Bool())) { c =>
@@ -29,7 +41,7 @@ class FaultLocatorTest extends FlatSpec with ChiselScalatestTester with Matchers
     }
     // Only check the filename to avoid this being too brittle as implementation changes
     exc.failedCodeFileNameAndLineNumberString.get should startWith ("DecoupledDriver.scala:")
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*27.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*39.*\)""")
   }
 
   it should "locate source lines, even in a different thread" in {
@@ -46,6 +58,6 @@ class FaultLocatorTest extends FlatSpec with ChiselScalatestTester with Matchers
       }
     }
     exc.failedCodeFileNameAndLineNumberString.get should startWith ("DecoupledDriver.scala:")
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*44.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*56.*\)""")
   }
 }


### PR DESCRIPTION
Resolves #18 

- Remove blocking `region(...) { ... }` API, regions now declared with `fork.withRegion(...) { ... }`.
- Add `.joinAndStep(clock)` API to allow threads to join on another that usually executes afterward in the cycle. This structurally enforces that the thread cannot go back in time, but schedules it to run on a future timeslot.
- Support tracing (source line fault locator on a failed expect) across threads, going up parent forks.