### PR TITLE
Add experimental with[Option] to run, high/low() on clock

### DIFF
--- a/src/main/scala/chisel3/tester/ChiselScalatestTester.scala
+++ b/src/main/scala/chisel3/tester/ChiselScalatestTester.scala
@@ -12,8 +12,7 @@ import scala.util.DynamicVariable
 
 trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvInterface { this: TestSuite =>
   class TestBuilder[T <: MultiIOModule](val dutGen: () => T,
-      val execOptions: Option[ExecutionOptionsManager], val testOptions: Option[TesterOptions]
-    ) {
+      val execOptions: Option[ExecutionOptionsManager], val testOptions: Option[TesterOptions]) {
     protected def getTestOptions: TesterOptions = {
       val test = scalaTestContext.value.get
       TesterOptions(test.name, test.configMap.contains("writeVcd"))
@@ -40,10 +39,10 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
   // Stack trace data to help generate more informative (and localizable) failure messages
   var topFileName: Option[String] = None  // best guess at the testdriver top filename
 
-  private[tester] def runTest[T <: MultiIOModule](tester: BackendInstance[T])(testFn: T => Unit) {
+  private def runTest[T <: MultiIOModule](tester: BackendInstance[T])(testFn: T => Unit) {
     // Try and get the user's top-level test filename
     val internalFiles = Set("ChiselScalatestTester.scala", "BackendInterface.scala", "TestEnvInterface.scala")
-    val topFileNameGuess = (new Throwable).getStackTrace.apply(4).getFileName
+    val topFileNameGuess = (new Throwable).getStackTrace.apply(2).getFileName
     if (internalFiles.contains(topFileNameGuess)) {
       println("Unable to guess top-level testdriver filename from stack trace")
       topFileName = None

--- a/src/main/scala/chisel3/tester/ChiselScalatestTester.scala
+++ b/src/main/scala/chisel3/tester/ChiselScalatestTester.scala
@@ -2,15 +2,31 @@
 
 package chisel3.tester
 
+import firrtl.ExecutionOptionsManager
 import chisel3.experimental.MultiIOModule
 import chisel3.tester.internal.{BackendInstance, Context, FailedExpectException, TestEnvInterface, TesterOptions}
-import firrtl.ExecutionOptionsManager
 import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
 
 import scala.util.DynamicVariable
 
 trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvInterface { this: TestSuite =>
+  class TestBuilder[T <: MultiIOModule](val dutGen: () => T,
+      val execOptions: Option[ExecutionOptionsManager], val testOptions: Option[TesterOptions]
+    ) {
+    protected def getTestOptions: TesterOptions = {
+      val test = scalaTestContext.value.get
+      TesterOptions(test.name, test.configMap.contains("writeVcd"))
+    }
+
+    def apply(testFn: T => Unit): Unit = {
+      runTest(defaults.createDefaultTester(dutGen, testOptions.getOrElse(getTestOptions), execOptions))(testFn)
+    }
+    // TODO: in the future, allow reset and re-use of a compiled design to avoid recompilation cost per test
+
+    val outer: ChiselScalatestTester = ChiselScalatestTester.this
+  }
+
   // Provide test fixture data as part of 'global' context during test runs
   protected var scalaTestContext = new DynamicVariable[Option[NoArgTest]](None)
 
@@ -24,10 +40,10 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
   // Stack trace data to help generate more informative (and localizable) failure messages
   var topFileName: Option[String] = None  // best guess at the testdriver top filename
 
-  private def runTest[T <: MultiIOModule](tester: BackendInstance[T])(testFn: T => Unit) {
+  private[tester] def runTest[T <: MultiIOModule](tester: BackendInstance[T])(testFn: T => Unit) {
     // Try and get the user's top-level test filename
-    val internalFiles = Set("ChiselScalatestTester.scala", "BackendInterface.scala")
-    val topFileNameGuess = (new Throwable).getStackTrace.apply(3).getFileName
+    val internalFiles = Set("ChiselScalatestTester.scala", "BackendInterface.scala", "TestEnvInterface.scala")
+    val topFileNameGuess = (new Throwable).getStackTrace.apply(4).getFileName
     if (internalFiles.contains(topFileNameGuess)) {
       println("Unable to guess top-level testdriver filename from stack trace")
       topFileName = None
@@ -48,17 +64,7 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
     }
   }
 
-  def getTestOptions: TesterOptions = {
-    val test = scalaTestContext.value.get
-    TesterOptions(test.name, test.configMap.contains("writeVcd"))
-  }
-
-  // This should be the only user-called function
-  def test[T <: MultiIOModule](dutGen: => T)(testFn: T => Unit) {
-    runTest(defaults.createDefaultTester(() => dutGen, getTestOptions, None))(testFn)
-  }
-
-  def test[T <: MultiIOModule](dutGen: => T, execOptions: ExecutionOptionsManager)(testFn: T => Unit) {
-    runTest(defaults.createDefaultTester(() => dutGen, getTestOptions, Some(execOptions)))(testFn)
+  def test[T <: MultiIOModule](dutGen: => T): TestBuilder[T] = {
+    new TestBuilder(() => dutGen, None, None)
   }
 }

--- a/src/main/scala/chisel3/tester/RawTester.scala
+++ b/src/main/scala/chisel3/tester/RawTester.scala
@@ -28,13 +28,8 @@ private class RawTester(testName: String) extends Assertions with TestEnvInterfa
     TesterOptions(topFileName.get, writeVcd = false)
   }
 
-  // This should be the only user-called function
   def test[T <: MultiIOModule](dutGen: => T)(testFn: T => Unit) {
     runTest(defaults.createDefaultTester(() => dutGen, getTestOptions, None))(testFn)
-  }
-
-  def test[T <: MultiIOModule](dutGen: => T, execOptions: ExecutionOptionsManager)(testFn: T => Unit) {
-    runTest(defaults.createDefaultTester(() => dutGen, getTestOptions, Some(execOptions)))(testFn)
   }
 }
 

--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -60,6 +60,16 @@ class TreadleBackend[T <: MultiIOModule](dut: T,
 
   def getModule: T = dut
 
+  override def pokeClock(signal: Clock, value: Boolean): Unit = {
+    val intValue = if (value) 1 else 0
+    doPoke(signal, intValue, new Throwable)
+    if (tester.peek(dataNames(signal)) != intValue) {
+      idleCycles.clear()
+    }
+    tester.poke(dataNames(signal), intValue)
+    debugLog(s"${resolveName(signal)} <- $intValue")
+  }
+
   override def pokeBits(signal: Bits, value: BigInt): Unit = {
     doPoke(signal, value, new Throwable)
     if (tester.peek(dataNames(signal)) != value) {

--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -61,11 +61,8 @@ class TreadleBackend[T <: MultiIOModule](dut: T,
   def getModule: T = dut
 
   override def pokeClock(signal: Clock, value: Boolean): Unit = {
+    // TODO: check thread ordering
     val intValue = if (value) 1 else 0
-    doPoke(signal, intValue, new Throwable)
-    if (tester.peek(dataNames(signal)) != intValue) {
-      idleCycles.clear()
-    }
     tester.poke(dataNames(signal), intValue)
     debugLog(s"${resolveName(signal)} <- $intValue")
   }

--- a/src/main/scala/chisel3/tester/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chisel3/tester/experimental/TestOptionBuilder.scala
@@ -1,0 +1,19 @@
+// See LICENSE for license details.
+
+package chisel3.tester.experimental
+
+import chisel3._
+import chisel3.experimental.MultiIOModule
+import chisel3.tester._
+
+package object TestOptionBuilder {
+  implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
+    def withExecOptions(opt: firrtl.ExecutionOptionsManager): ChiselScalatestTester#TestBuilder[T] = {
+      new x.outer.TestBuilder[T](x.dutGen, Some(opt), x.testOptions)
+    }
+
+    def withTesterOptions(opt: TesterOptions): ChiselScalatestTester#TestBuilder[T] = {
+      new x.outer.TestBuilder[T](x.dutGen, x.execOptions, Some(opt))
+    }
+  }
+}

--- a/src/main/scala/chisel3/tester/experimental/UncheckedClockPoke.scala
+++ b/src/main/scala/chisel3/tester/experimental/UncheckedClockPoke.scala
@@ -1,0 +1,31 @@
+// See LICENSE for license details.
+
+package chisel3.tester.experimental
+
+import chisel3._
+import chisel3.core.ActualDirection  // TODO needs to be a public API
+import chisel3.experimental.{DataMirror, MultiIOModule}
+import chisel3.tester._
+import chisel3.tester.internal.Context
+
+package object UncheckedClockPoke {
+  /** This provides a quick and dirty way to poke clocks. Inter-thread dependency is NOT checked,
+    * so it is up to you to understand the thread ordering semantics to use this correctly.
+    * Note that thread ordering IS deterministic, so you will NOT get a nondeterministic test.
+    */
+  implicit class UncheckedPokeableClock(signal: Clock) {
+    def high(): Unit = {
+      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
+        throw new UnpokeableException("Cannot only poke inputs")
+      }
+      Context().backend.pokeClock(signal, true)
+    }
+
+    def low(): Unit = {
+      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
+        throw new UnpokeableException("Cannot only poke inputs")
+      }
+      Context().backend.pokeClock(signal, false)
+    }
+  }
+}

--- a/src/main/scala/chisel3/tester/experimental/UncheckedClockPoke.scala
+++ b/src/main/scala/chisel3/tester/experimental/UncheckedClockPoke.scala
@@ -3,8 +3,7 @@
 package chisel3.tester.experimental
 
 import chisel3._
-import chisel3.core.ActualDirection  // TODO needs to be a public API
-import chisel3.experimental.{DataMirror, MultiIOModule}
+import chisel3.experimental.{DataMirror, Direction, MultiIOModule}
 import chisel3.tester._
 import chisel3.tester.internal.Context
 
@@ -15,14 +14,14 @@ package object UncheckedClockPoke {
     */
   implicit class UncheckedPokeableClock(signal: Clock) {
     def high(): Unit = {
-      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
+      if (DataMirror.directionOf(signal) != Direction.Input) {
         throw new UnpokeableException("Cannot only poke inputs")
       }
       Context().backend.pokeClock(signal, true)
     }
 
     def low(): Unit = {
-      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
+      if (DataMirror.directionOf(signal) != Direction.Input) {
         throw new UnpokeableException("Cannot only poke inputs")
       }
       Context().backend.pokeClock(signal, false)

--- a/src/main/scala/chisel3/tester/experimental/package.scala
+++ b/src/main/scala/chisel3/tester/experimental/package.scala
@@ -29,17 +29,11 @@ package object experimental {
     }
   }
 
-//  implicit class ChiselScalatestTesterOptions(x: ChiselScalatestTester) {
-//    // Experimental API, individual options must be specified with named args
-//    def test[T <: MultiIOModule](dutGen: => T, dummy: Int = 0,
-//        execOptions: Option[ExecutionOptionsManager] = None, testOptions: Option[TesterOptions] = None
-//        )(testFn: T => Unit) {
-//      x.runTest(defaults.createDefaultTester(() => dutGen,
-//        testOptions.getOrElse(x.getTestOptions), execOptions))(testFn)
-//    }
-//  }
-
-  implicit class uncheckedPokeableClock(signal: Clock) {
+  /** This provides a quick and dirty way to poke clocks. Inter-thread dependency is NOT checked,
+    * so it is up to you to understand the thread ordering semantics to use this correctly.
+    * Note that thread ordering IS deterministic, so you will NOT get a nondeterministic test.
+    */
+  implicit class UncheckedPokeableClock(signal: Clock) {
     def high(): Unit = {
       if (DataMirror.directionOf(signal) != ActualDirection.Input) {
         throw new UnpokeableException("Cannot only poke inputs")

--- a/src/main/scala/chisel3/tester/experimental/package.scala
+++ b/src/main/scala/chisel3/tester/experimental/package.scala
@@ -3,8 +3,40 @@
 package chisel3.tester
 
 import chisel3._
+import chisel3.experimental.MultiIOModule
+import firrtl.ExecutionOptionsManager
 
+/** Your warranty is now void.
+  *
+  * experimental contains cutting edge features that are, well, experimental, and carry no
+  * expectation of long-term support. We may break experimental APIs at any time. These may not
+  * work as expected, or may have unforeseen side effects, or may be powerful yet dangerous.
+  *
+  * You have been warned.
+  */
 package object experimental {
+  type TesterOptions = chisel3.tester.internal.TesterOptions
+  val TesterOptions = chisel3.tester.internal.TesterOptions  // expose this internal object, whose "API" is unstable
+
+  implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
+    def withExecOptions(opt: firrtl.ExecutionOptionsManager): ChiselScalatestTester#TestBuilder[T] = {
+      new x.outer.TestBuilder[T](x.dutGen, Some(opt), x.testOptions)
+    }
+    def withTesterOptions(opt: TesterOptions): ChiselScalatestTester#TestBuilder[T] = {
+      new x.outer.TestBuilder[T](x.dutGen, x.execOptions, Some(opt))
+    }
+  }
+
+//  implicit class ChiselScalatestTesterOptions(x: ChiselScalatestTester) {
+//    // Experimental API, individual options must be specified with named args
+//    def test[T <: MultiIOModule](dutGen: => T, dummy: Int = 0,
+//        execOptions: Option[ExecutionOptionsManager] = None, testOptions: Option[TesterOptions] = None
+//        )(testFn: T => Unit) {
+//      x.runTest(defaults.createDefaultTester(() => dutGen,
+//        testOptions.getOrElse(x.getTestOptions), execOptions))(testFn)
+//    }
+//  }
+
   implicit class uncheckedPokeableClock(x: Clock) {
 
   }

--- a/src/main/scala/chisel3/tester/experimental/package.scala
+++ b/src/main/scala/chisel3/tester/experimental/package.scala
@@ -3,7 +3,9 @@
 package chisel3.tester
 
 import chisel3._
-import chisel3.experimental.MultiIOModule
+import chisel3.core.ActualDirection  // TODO needs to be a public API
+import chisel3.experimental.{DataMirror, MultiIOModule}
+import chisel3.tester.internal._
 import firrtl.ExecutionOptionsManager
 
 /** Your warranty is now void.
@@ -37,7 +39,19 @@ package object experimental {
 //    }
 //  }
 
-  implicit class uncheckedPokeableClock(x: Clock) {
+  implicit class uncheckedPokeableClock(signal: Clock) {
+    def high(): Unit = {
+      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
+        throw new UnpokeableException("Cannot only poke inputs")
+      }
+      Context().backend.pokeClock(signal, true)
+    }
 
+    def low(): Unit = {
+      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
+        throw new UnpokeableException("Cannot only poke inputs")
+      }
+      Context().backend.pokeClock(signal, false)
+    }
   }
 }

--- a/src/main/scala/chisel3/tester/experimental/package.scala
+++ b/src/main/scala/chisel3/tester/experimental/package.scala
@@ -19,33 +19,4 @@ import firrtl.ExecutionOptionsManager
 package object experimental {
   type TesterOptions = chisel3.tester.internal.TesterOptions
   val TesterOptions = chisel3.tester.internal.TesterOptions  // expose this internal object, whose "API" is unstable
-
-  implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
-    def withExecOptions(opt: firrtl.ExecutionOptionsManager): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, Some(opt), x.testOptions)
-    }
-    def withTesterOptions(opt: TesterOptions): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, x.execOptions, Some(opt))
-    }
-  }
-
-  /** This provides a quick and dirty way to poke clocks. Inter-thread dependency is NOT checked,
-    * so it is up to you to understand the thread ordering semantics to use this correctly.
-    * Note that thread ordering IS deterministic, so you will NOT get a nondeterministic test.
-    */
-  implicit class UncheckedPokeableClock(signal: Clock) {
-    def high(): Unit = {
-      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
-        throw new UnpokeableException("Cannot only poke inputs")
-      }
-      Context().backend.pokeClock(signal, true)
-    }
-
-    def low(): Unit = {
-      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
-        throw new UnpokeableException("Cannot only poke inputs")
-      }
-      Context().backend.pokeClock(signal, false)
-    }
-  }
 }

--- a/src/main/scala/chisel3/tester/experimental/package.scala
+++ b/src/main/scala/chisel3/tester/experimental/package.scala
@@ -2,12 +2,6 @@
 
 package chisel3.tester
 
-import chisel3._
-import chisel3.core.ActualDirection  // TODO needs to be a public API
-import chisel3.experimental.{DataMirror, MultiIOModule}
-import chisel3.tester.internal._
-import firrtl.ExecutionOptionsManager
-
 /** Your warranty is now void.
   *
   * experimental contains cutting edge features that are, well, experimental, and carry no

--- a/src/main/scala/chisel3/tester/internal/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/internal/BackendInterface.scala
@@ -31,6 +31,10 @@ class TesterThreadList(protected val elts: Seq[AbstractTesterThread]) {
 /** Common interface definition for tester backends. Internal API.
   */
 trait BackendInterface {
+  /** Writes a value to a clock.
+    */
+  def pokeClock(signal: Clock, value: Boolean): Unit
+
   /** Writes a value to a writable wire.
     * Throws an exception if write is not writable.
     */

--- a/src/main/scala/chisel3/tester/package.scala
+++ b/src/main/scala/chisel3/tester/package.scala
@@ -4,8 +4,7 @@ package chisel3
 
 import scala.language.implicitConversions
 import chisel3.tester.internal._
-import chisel3.core.ActualDirection  // TODO needs to be a public API
-import chisel3.experimental.{DataMirror, FixedPoint}
+import chisel3.experimental.{DataMirror, Direction, FixedPoint}
 import chisel3.util._
 
 class NotLiteralException(message: String) extends Exception(message)
@@ -20,7 +19,7 @@ package object tester {
   import chisel3.internal.firrtl.{LitArg, ULit, SLit}
   implicit class testableData[T <: Data](x: T) {
     protected def pokeBits(signal: Bits, value: BigInt): Unit = {
-      if (DataMirror.directionOf(signal) != ActualDirection.Input) {
+      if (DataMirror.directionOf(signal) != Direction.Input) {
         throw new UnpokeableException("Cannot only poke inputs")
       }
       Context().backend.pokeBits(signal, value)

--- a/src/test/scala/chisel3/tests/AsyncResetRegTest.scala
+++ b/src/test/scala/chisel3/tests/AsyncResetRegTest.scala
@@ -4,7 +4,8 @@ package chisel3.tests
 
 import chisel3._
 import chisel3.tester._
-import chisel3.tester.experimental._
+import chisel3.tester.experimental.{AsyncResetReg, AsyncResetBlackBoxFactory}
+import chisel3.tester.experimental.TestOptionBuilder._
 import firrtl.ExecutionOptionsManager
 import treadle.HasTreadleSuite
 import org.scalatest._

--- a/src/test/scala/chisel3/tests/AsyncResetRegTest.scala
+++ b/src/test/scala/chisel3/tests/AsyncResetRegTest.scala
@@ -60,17 +60,20 @@ class AsyncResetRegTest extends FreeSpec with ChiselScalatestTester {
     )
   }
   "register is zero, after tester startup's default reset" in {
-    test(new AsyncResetRegModule(0), manager) { dut =>
+    test(new AsyncResetRegModule(0))
+        .withExecOptions(manager) { dut =>
       dut.io.out.expect(0.U)
     }
   }
   "register is one, after tester startup's default reset" in {
-    test(new AsyncResetRegModule(1), manager) { dut =>
+    test(new AsyncResetRegModule(1))
+        .withExecOptions(manager) { dut =>
       dut.io.out.expect(1.U)
     }
   }
   "reset a register works after register has been altered" in {
-    test(new AsyncResetRegModule(1), manager) { dut =>
+    test(new AsyncResetRegModule(1))
+        .withExecOptions(manager) { dut =>
       // The register starts at 1 after default reset in tester startup
       dut.io.out.expect(1.U)
 
@@ -102,7 +105,8 @@ class AsyncResetRegTest extends FreeSpec with ChiselScalatestTester {
     }
   }
   "de-assert reset behaviour" in {
-    test(new AsyncResetRegModule(1), manager) { dut =>
+    test(new AsyncResetRegModule(1))
+        .withExecOptions(manager) { dut =>
       // register is reset at startup, and set to zero by poking
       dut.clock.step()
       dut.io.out.expect(0.U)
@@ -124,7 +128,8 @@ class AsyncResetRegTest extends FreeSpec with ChiselScalatestTester {
     }
   }
   "feedback into itself" in {
-    test(new AsyncResetFeedbackModule, manager) { dut =>
+    test(new AsyncResetFeedbackModule)
+        .withExecOptions(manager) { dut =>
       dut.io.out(0).expect(0.U)
       dut.io.out(1).expect(1.U)
 

--- a/src/test/scala/chisel3/tests/ClockPokeTest.scala
+++ b/src/test/scala/chisel3/tests/ClockPokeTest.scala
@@ -1,0 +1,47 @@
+package chisel3.tests
+
+import org.scalatest._
+
+import chisel3._
+import chisel3.experimental.MultiIOModule
+import chisel3.util._
+import chisel3.tester._
+import chisel3.tester.experimental._
+
+class ClockPokeTest extends FlatSpec with ChiselScalatestTester {
+  behavior of "Testers2 with a clock input"
+
+  it should "work as expected" in {
+    test(new MultiIOModule {
+      val inClock = IO(Input(Clock()))
+      val out = IO(Output(UInt(8.W)))
+
+      withClock(inClock) {
+        out := Counter(true.B, 8)._1
+      }
+    }) { c =>
+      c.inClock.low()
+      c.out.expect(0.U)
+
+      // Main clock should do nothing
+      c.clock.step()
+      c.out.expect(0.U)
+      c.clock.step()
+      c.out.expect(0.U)
+
+      // Output should advance on rising edge, even without main clock edge
+      c.inClock.high()
+      c.out.expect(1.U)
+
+      // Repeated high should do nothing
+      c.inClock.high()
+      c.out.expect(1.U)
+
+      // and again
+      c.inClock.low()
+      c.out.expect(1.U)
+      c.inClock.high()
+      c.out.expect(2.U)
+    }
+  }
+}

--- a/src/test/scala/chisel3/tests/ClockPokeTest.scala
+++ b/src/test/scala/chisel3/tests/ClockPokeTest.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.experimental.MultiIOModule
 import chisel3.util._
 import chisel3.tester._
-import chisel3.tester.experimental._
+import chisel3.tester.experimental.UncheckedClockPoke._
 
 class ClockPokeTest extends FlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with a clock input"


### PR DESCRIPTION
Resolves #29 

Perhaps unsurprisingly, this also went deep down the refactor rabbit hole.

- Refactors `run(dutGen => T)` to return a TestBuilder, which can be chain applied to run a test.
- Adds an experimental implicit conversion on the ChiselScalatestTester TestBuilder to allow `.withExecOptions`, `.withTesterOptions`. See the AsyncResetRegTest for an usage example.
- Removes the `run(dutGen, execOptions)` methods, so you have to import experimental to specify options.
  - Note: TestBuilder is not provided for RawTester (so there's no way to specify execution options / tester options there). But the primary use for that is probably simple examples, where you probably don't need this power anyways. If this is wrong (as in you have a legit use case), I can add a TestBuilder object to RawTester.
- Expose `TesterOptions` in experimental.
- Add `Clock.high()`, `Clock.low()` in experimental, which does a unchecked clock poke (as in, if you use this with threads, you need to know how Testers2 orders threads). Proper clock poking is under discussion in #14, but this acts as temporary solution for those who need to poke clocks now.
