### PR TITLE
Fix 2.11 test failure

### DIFF
--- a/src/test/scala/chisel3/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chisel3/tests/OptionsPassingTest.scala
@@ -32,9 +32,12 @@ class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matche
             File.separator +
             sanitizeFileName(s"Testers2 should write vcd output when passing in a WriteVcdAnnotation"))
 
-    testDir.listFiles.exists { f =>
+    val vcdFileOpt = testDir.listFiles.find { f =>
       f.getPath.endsWith(".vcd")
-    } should be (true)
+    }
+
+    vcdFileOpt.isDefined should be (true)
+    vcdFileOpt.get.delete()
   }
 
   it should "allow turning on verbose mode" in {

--- a/src/test/scala/chisel3/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chisel3/tests/OptionsPassingTest.scala
@@ -16,7 +16,7 @@ class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matche
   it should "write vcd output when passing in a WriteVcdAnnotation" in {
     test(new Module {
       val io = IO(new Bundle {
-        val a = Input(UInt(8.W));
+        val a = Input(UInt(8.W))
         val b = Output(UInt(8.W))
       })
       io.b := io.a
@@ -28,16 +28,13 @@ class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matche
       c.io.b.expect(42.U)
     }
 
-    val vcdFileName = "test_run_dir" +
+    val testDir = new File("test_run_dir" +
             File.separator +
-            sanitizeFileName(s"Testers2 should write vcd output when passing in a WriteVcdAnnotation") +
-            File.separator +
-            sanitizeFileName("OptionsPassingTestanon2") +
-            ".vcd"
+            sanitizeFileName(s"Testers2 should write vcd output when passing in a WriteVcdAnnotation"))
 
-    val vcdFile = new File(vcdFileName)
-    vcdFile.exists() should be (true)
-    vcdFile.delete()
+    testDir.listFiles.exists { f =>
+      f.getPath.endsWith(".vcd")
+    } should be (true)
   }
 
   it should "allow turning on verbose mode" in {


### PR DESCRIPTION
2.11 scalatest api returns different test context name
than 2.12, this fix checks to make sure a vcd file was created by using less restrictive name checking.