### PR TITLE
Beginning support for Verilator backend.

### DIFF
--- a/src/main/scala/chisel3/tester/backends/BackendExecutive.scala
+++ b/src/main/scala/chisel3/tester/backends/BackendExecutive.scala
@@ -1,0 +1,64 @@
+// See LICENSE for license details.
+
+package chisel3.tester.backends
+
+import chisel3.experimental.{BaseModule, MultiIOModule}
+import chisel3.internal.firrtl.Circuit
+import chisel3.tester.internal.BackendInstance
+import chisel3.{Data, Element, Record, Vec}
+import firrtl.AnnotationSeq
+import firrtl.annotations.ReferenceTarget
+import firrtl.transforms.CombinationalPath
+
+trait BackendExecutive {
+  def getTopModule(circuit: Circuit): BaseModule = {
+    (circuit.components find (_.name == circuit.name)).get.id
+  }
+
+  /** Returns a Seq of (data reference, fully qualified element names) for the input.
+    * name is the name of data
+    */
+  def getDataNames(name: String, data: Data): Seq[(Data, String)] = Seq(data -> name) ++ (data match {
+    case _: Element => Seq()
+    case b: Record => b.elements.toSeq flatMap {case (n, e) => getDataNames(s"${name}_$n", e)}
+    case v: Vec[_] => v.zipWithIndex flatMap {case (e, i) => getDataNames(s"${name}_$i", e)}
+  })
+
+  /** This creates some kind of map of combinational paths between inputs and outputs.
+    *
+    * @param dut       use this to figure out which paths involve top level iO
+    * @param paths     combinational paths found by firrtl pass CheckCombLoops
+    * @param dataNames a map between a port's Data and it's string name
+    * @param componentToName used to map [[ReferenceTarget]]s  found in paths into correct local string form
+    * @return
+    */
+  //TODO: better name
+  //TODO: check for aliasing in here
+  //TODO graceful error message if there is an unexpected combinational path element?
+  def combinationalPathsToData(
+    dut: BaseModule,
+    paths: Seq[CombinationalPath],
+    dataNames: Map[Data, String],
+    componentToName: ReferenceTarget => String
+  ): Map[Data, Set[Data]] = {
+
+    val nameToData = dataNames.map(_.swap)
+    val filteredPaths = paths.filter { p =>  // only keep paths involving top-level IOs
+      p.sink.module == dut.name && p.sources.exists(_.module == dut.name)
+    }
+    val filterPathsByName = filteredPaths.map { p =>  // map ComponentNames in paths into string forms
+      val mappedSources = p.sources.filter(_.module == dut.name).map { component =>
+          componentToName(component)
+      }
+      componentToName(p.sink) -> mappedSources
+    }
+    val mapPairs = filterPathsByName.map { case (sink, sources) =>  // convert to Data
+      nameToData(sink) -> sources.map { source =>
+        nameToData(source)
+      }.toSet
+    }
+    mapPairs.toMap
+  }
+
+  def start[T <: MultiIOModule](dutGen: () => T, annotationSeq: AnnotationSeq): BackendInstance[T]
+}

--- a/src/main/scala/chisel3/tester/backends/treadle/TreadleExecutive.scala
+++ b/src/main/scala/chisel3/tester/backends/treadle/TreadleExecutive.scala
@@ -1,0 +1,57 @@
+// See LICENSE for license details.
+
+package chisel3.tester.backends.treadle
+
+import chisel3.experimental.{DataMirror, MultiIOModule}
+import chisel3.stage.{ChiselStage, NoRunFirrtlCompilerAnnotation}
+import chisel3.tester.backends.BackendExecutive
+import chisel3.tester.internal._
+import firrtl.annotations.ReferenceTarget
+import firrtl.transforms.{CheckCombLoops, CombinationalPath}
+import treadle.stage.TreadleTesterPhase
+import treadle.{TreadleCircuitStateAnnotation, TreadleTesterAnnotation}
+
+object TreadleExecutive extends BackendExecutive {
+  import firrtl._
+
+  def componentToName(component: ReferenceTarget): String = {
+    component.name
+  }
+
+  def start[T <: MultiIOModule](dutGen: () => T, annotationSeq: AnnotationSeq): BackendInstance[T] = {
+
+    // Force a cleanup: long SBT runs tend to fail with memory issues
+    System.gc()
+
+    val generatorAnnotation = chisel3.stage.ChiselGeneratorAnnotation(dutGen)
+
+    val circuit = generatorAnnotation.elaborate.circuit
+    val dut = getTopModule(circuit).asInstanceOf[T]
+    val portNames = DataMirror.modulePorts(dut).flatMap { case (name, data) =>
+      getDataNames(name, data).toList
+    }.toMap
+
+    val chiseledAnnotations = (new ChiselStage).run(
+      annotationSeq ++ Seq(generatorAnnotation, NoRunFirrtlCompilerAnnotation)
+    )
+
+    val treadledAnnotations = TreadleTesterPhase.transform(chiseledAnnotations)
+
+    val treadleTester = treadledAnnotations.collectFirst { case TreadleTesterAnnotation(t) => t }.getOrElse(
+      throw new Exception(
+        s"TreadleTesterPhase could not build a treadle tester from these annotations" +
+        chiseledAnnotations.mkString("Annotations:\n", "\n  ", "")
+      )
+    )
+
+    val circuitState = treadledAnnotations.collectFirst { case TreadleCircuitStateAnnotation(s) => s }.get
+    val pathAnnotations = (new CheckCombLoops).execute(circuitState).annotations
+    val paths = pathAnnotations.collect {
+      case c: CombinationalPath => c
+    }
+
+    val pathsAsData = combinationalPathsToData(dut, paths, portNames, componentToName)
+
+    new TreadleBackend(dut, portNames, pathsAsData, treadleTester)
+  }
+}

--- a/src/main/scala/chisel3/tester/defaults.scala
+++ b/src/main/scala/chisel3/tester/defaults.scala
@@ -3,6 +3,7 @@
 package chisel3.tester
 
 import chisel3.experimental.MultiIOModule
+import chisel3.tester.backends.treadle.TreadleExecutive
 import chisel3.tester.internal._
 import firrtl.AnnotationSeq
 


### PR DESCRIPTION
- Re-organize packages
  - create backends
  - add a treadle backend
- Generalize backends in anticipation of verilator
  - create BackendExecutive
    - combinational path building should be shared so moved to here.
  - new TreadleBackend
    - Uses BackendExecutive
    - Eliminate try block in object
      - Simplifies debugging
  - Split out TreadleExecutive from TreadleBackend
  - ThreadedBackend
    - provides dut access
      - this required parameterization of trait with dut's type