### PR TITLE
Fix toolchain so treadle supports boringutils

### DIFF
--- a/src/main/scala/chisel3/tester/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chisel3/tester/experimental/TestOptionBuilder.scala
@@ -5,9 +5,11 @@ package chisel3.tester.experimental
 import chisel3._
 import chisel3.tester._
 import chisel3.tester.internal.{TreadleBackendAnnotation, VerilatorBackendAnnotation}
-import firrtl.stage.CompilerAnnotation
-import firrtl.{AnnotationSeq, ExecutionOptionsManager, LowFirrtlCompiler, NoneCompiler, VerilogCompiler}
 import treadle.HasTreadleSuite
+import firrtl.stage.CompilerAnnotation
+import firrtl.{
+  AnnotationSeq, ExecutionOptionsManager, LowFirrtlCompiler, MinimumVerilogCompiler,
+  NoneCompiler, SystemVerilogCompiler, VerilogCompiler}
 
 package object TestOptionBuilder {
   implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
@@ -18,9 +20,11 @@ package object TestOptionBuilder {
     @deprecated("Use withAnnotations instead")
     def withExecOptions(manager: ExecutionOptionsManager with HasTreadleSuite): ChiselScalatestTester#TestBuilder[T] = {
       val annos = manager.toAnnotationSeq.map {
-        case CompilerAnnotation(compiler) if compiler.isInstanceOf[LowFirrtlCompiler] => TreadleBackendAnnotation
-        case CompilerAnnotation(compiler) if compiler.isInstanceOf[NoneCompiler]      => TreadleBackendAnnotation
-        case CompilerAnnotation(_)                                                    => VerilatorBackendAnnotation
+        case CompilerAnnotation(compiler) if compiler.isInstanceOf[LowFirrtlCompiler]      => TreadleBackendAnnotation
+        case CompilerAnnotation(compiler) if compiler.isInstanceOf[NoneCompiler]           => TreadleBackendAnnotation
+        case CompilerAnnotation(compiler) if compiler.isInstanceOf[VerilogCompiler]        => VerilatorBackendAnnotation
+        case CompilerAnnotation(compiler) if compiler.isInstanceOf[MinimumVerilogCompiler] => VerilatorBackendAnnotation
+        case CompilerAnnotation(compiler) if compiler.isInstanceOf[SystemVerilogCompiler]  => VerilatorBackendAnnotation
         case anno => anno
       }
 

--- a/src/main/scala/chisel3/tester/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chisel3/tester/experimental/TestOptionBuilder.scala
@@ -4,7 +4,9 @@ package chisel3.tester.experimental
 
 import chisel3._
 import chisel3.tester._
-import firrtl.{AnnotationSeq, ExecutionOptionsManager}
+import chisel3.tester.internal.{TreadleBackendAnnotation, VerilatorBackendAnnotation}
+import firrtl.stage.CompilerAnnotation
+import firrtl.{AnnotationSeq, ExecutionOptionsManager, LowFirrtlCompiler, NoneCompiler, VerilogCompiler}
 import treadle.HasTreadleSuite
 
 package object TestOptionBuilder {
@@ -15,7 +17,14 @@ package object TestOptionBuilder {
 
     @deprecated("Use withAnnotations instead")
     def withExecOptions(manager: ExecutionOptionsManager with HasTreadleSuite): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, manager.toAnnotationSeq)
+      val annos = manager.toAnnotationSeq.map {
+        case CompilerAnnotation(compiler) if compiler.isInstanceOf[LowFirrtlCompiler] => TreadleBackendAnnotation
+        case CompilerAnnotation(compiler) if compiler.isInstanceOf[NoneCompiler]      => TreadleBackendAnnotation
+        case CompilerAnnotation(_)                                                    => VerilatorBackendAnnotation
+        case anno => anno
+      }
+
+      new x.outer.TestBuilder[T](x.dutGen, annos)
     }
 
     @deprecated("Use withAnnotations instead")

--- a/src/test/scala/chisel3/tests/BoreTest.scala
+++ b/src/test/scala/chisel3/tests/BoreTest.scala
@@ -2,11 +2,9 @@
 
 package chisel3.tests
 
-import org.scalatest._
 import chisel3._
 import chisel3.tester._
-import chisel3.tester.experimental.TestOptionBuilder._
-import chisel3.tester.internal.VerilatorBackendAnnotation
+import org.scalatest._
 
 class BoreTest extends FlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
@@ -31,9 +29,7 @@ class BoreTest extends FlatSpec with ChiselScalatestTester with Matchers {
   }
 
   it should "honor Wiring Transform for BoringUtils" in {
-//    val annos = Seq(VerilatorBackendAnnotation)
-    val annos = Seq()
-    test(new Top).withAnnotations(annos) { c =>
+    test(new Top) { c =>
       c.y.expect(42.U)
     }
   }

--- a/src/test/scala/chisel3/tests/BoreTest.scala
+++ b/src/test/scala/chisel3/tests/BoreTest.scala
@@ -1,0 +1,40 @@
+// See LICENSE for license details.
+
+package chisel3.tests
+
+import org.scalatest._
+import chisel3._
+import chisel3.tester._
+import chisel3.tester.experimental.TestOptionBuilder._
+import chisel3.tester.internal.VerilatorBackendAnnotation
+
+class BoreTest extends FlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2"
+
+  class Constant extends MultiIOModule {
+    val x = Reg(UInt(6.W))
+    x := 42.U
+  }
+
+  class Expect extends MultiIOModule {
+    val y = IO(Output(UInt(6.W)))
+    y := 0.U
+  }
+
+  class Top extends MultiIOModule {
+    val y = IO(Output(UInt(6.W)))
+    val constant = Module(new Constant)
+    val expect = Module(new Expect)
+    y := expect.y
+
+    util.experimental.BoringUtils.bore(constant.x, Seq(expect.y))
+  }
+
+  it should "honor Wiring Transform for BoringUtils" in {
+//    val annos = Seq(VerilatorBackendAnnotation)
+    val annos = Seq()
+    test(new Top).withAnnotations(annos) { c =>
+      c.y.expect(42.U)
+    }
+  }
+}

--- a/src/test/scala/chisel3/tests/MixedVec.scala
+++ b/src/test/scala/chisel3/tests/MixedVec.scala
@@ -1,0 +1,33 @@
+// See README.md for license details.
+
+package chisel3.tests
+
+import chisel3._
+import chisel3.tester._
+import org.scalatest.FreeSpec
+
+
+class VecIO extends Bundle {
+  val x = UInt(5.W)
+}
+
+class UsesVec extends MultiIOModule {
+  val in   = IO(Input(Vec(4, new VecIO)))
+  val addr = IO(Input(UInt(8.W)))
+  val out  = IO(Output(UInt(5.W)))
+
+  out := in(addr).x
+}
+
+class UsesVecSpec extends FreeSpec with ChiselScalatestTester {
+  "run" in {
+    test(new UsesVec) { c =>
+      c.in(0).x.poke(5.U)
+      c.in(1).x.poke(5.U)
+      c.in(2).x.poke(4.U)
+      c.addr.poke(2.U)
+      c.clock.step()
+      c.out.expect(4.U)
+    }
+  }
+}

--- a/src/test/scala/chisel3/tests/OptionsBackwardCompatibilityTest.scala
+++ b/src/test/scala/chisel3/tests/OptionsBackwardCompatibilityTest.scala
@@ -12,11 +12,17 @@ import treadle.{BlackBoxFactoriesAnnotation, HasTreadleSuite}
 
 /** This test uses a deprecated class and method to test backward compatibility
   *
+  * @note This test is used to illustrate workaround for treadle
+  *
   */
 class OptionsBackwardCompatibilityTest extends FreeSpec with ChiselScalatestTester {
   private val manager = new ExecutionOptionsManager("asyncResetRegTest") with HasTreadleSuite {
     treadleOptions = treadleOptions.copy(
       blackBoxFactories = Seq(new AsyncResetBlackBoxFactory)
+    )
+    // This is the backward compatible way to use the Treadle backend, which is necessary for this test to run.
+    firrtlOptions = firrtlOptions.copy(
+      compilerName = "none"
     )
 
     def toAnnotations: AnnotationSeq = Seq(BlackBoxFactoriesAnnotation(treadleOptions.blackBoxFactories))

--- a/src/test/scala/chisel3/tests/VecPokeExpectTest.scala
+++ b/src/test/scala/chisel3/tests/VecPokeExpectTest.scala
@@ -6,28 +6,26 @@ import chisel3._
 import chisel3.tester._
 import org.scalatest.FreeSpec
 
-
-class VecIO extends Bundle {
-  val x = UInt(5.W)
-}
-
 class UsesVec extends MultiIOModule {
-  val in   = IO(Input(Vec(4, new VecIO)))
+  val in   = IO(Input(Vec(4, UInt(5.W))))
   val addr = IO(Input(UInt(8.W)))
   val out  = IO(Output(UInt(5.W)))
 
-  out := in(addr).x
+  out := in(addr)
 }
 
 class UsesVecSpec extends FreeSpec with ChiselScalatestTester {
   "run" in {
     test(new UsesVec) { c =>
-      c.in(0).x.poke(5.U)
-      c.in(1).x.poke(5.U)
-      c.in(2).x.poke(4.U)
-      c.addr.poke(2.U)
-      c.clock.step()
-      c.out.expect(4.U)
+      c.in(0).poke(5.U)
+      c.in(1).poke(6.U)
+      c.in(2).poke(7.U)
+      c.in(3).poke(8.U)
+
+      for(vecIndex <- c.in.indices) {
+        c.addr.poke(vecIndex.U)
+        c.out.expect((vecIndex + 5).U)
+      }
     }
   }
 }


### PR DESCRIPTION
- Add the low firrtl compiler to TreadleExecutive
  - Send hint to treadle so it knows compiled form
- Fix backward compatibility with Driver
  - Check compiler type to help figure out the backend
  - Backward compatibility only supported for treadle and verilator
- Add boringutils test
- Backward compatibilty requires compile workaround
  - Can we just eliminate Driver compatibility mode here???
- Fixed CopyVpiFiles
  - looks like this might fail if early file was there but a late one wasn't
  - this code came from chisel-testers
- Fix top level test names
  - behavior of "Testers2 with Vcs"
  - behavior of "Testers2 with Verilator"
- Shortened VCS to just see if a simple circuit will build and simulate.
  - in long run we still need mechanism to run an arbitrary test with arbitrary backend