### PR TITLE
Fix broken Seq -> Map replacement.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ publishTo := {
 }
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-val defaultVersions = Map(
+val defaultVersions = Seq(
   "chisel3" -> "3.3-SNAPSHOT",
   "treadle" -> "1.2-SNAPSHOT"
 )


### PR DESCRIPTION
Undo broken attempt to convert `defaultVersions` to a Map.
