### PR TITLE
support enqueue/dequeue of IrrevocableIO

### DIFF
--- a/src/main/scala/chisel3/tester/DecoupledDriver.scala
+++ b/src/main/scala/chisel3/tester/DecoupledDriver.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.util._
 
 // implicit class, cannot maintain state
-class DecoupledDriver[T <: Data](x: DecoupledIO[T]) {
+class DecoupledDriver[T <: Data](x: ReadyValidIO[T]) {
   // Source (enqueue) functions
   //
   def initSource(): this.type = {

--- a/src/main/scala/chisel3/tester/package.scala
+++ b/src/main/scala/chisel3/tester/package.scala
@@ -173,5 +173,7 @@ package object tester {
 
   implicit def decoupledToDriver[T <: Data](x: DecoupledIO[T]) = new DecoupledDriver(x)
 
+  implicit def irrevocableToDriver[T <: Data](x: IrrevocableIO[T]) = new DecoupledDriver(x)
+
   implicit def validToDriver[T <: Data](x: ValidIO[T]) = new ValidDriver(x)
 }

--- a/src/main/scala/chisel3/tester/package.scala
+++ b/src/main/scala/chisel3/tester/package.scala
@@ -171,9 +171,7 @@ package object tester {
     }
   }
 
-  implicit def decoupledToDriver[T <: Data](x: DecoupledIO[T]) = new DecoupledDriver(x)
-
-  implicit def irrevocableToDriver[T <: Data](x: IrrevocableIO[T]) = new DecoupledDriver(x)
+  implicit def decoupledToDriver[T <: Data](x: ReadyValidIO[T]) = new DecoupledDriver(x)
 
   implicit def validToDriver[T <: Data](x: ValidIO[T]) = new ValidDriver(x)
 }

--- a/src/test/scala/chisel3/tests/QueueTest.scala
+++ b/src/test/scala/chisel3/tests/QueueTest.scala
@@ -4,6 +4,8 @@ import org.scalatest._
 
 import chisel3._
 import chisel3.tester._
+import chisel3.util._
+
 
 class QueueTest extends FlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with Queue"
@@ -57,4 +59,28 @@ class QueueTest extends FlatSpec with ChiselScalatestTester {
       }.join()
     }
   }
+
+  it should "work with IrrevocableIO" in{
+    test(new Module{
+      val io = IO(new Bundle{
+        val in = Flipped(Irrevocable(UInt(8.W)))
+        val out = Irrevocable(UInt(8.W))
+      })
+      val full = RegInit(false.B)
+      when(io.in.fire()){ full := true.B }.elsewhen(io.out.fire()){ full := false.B }
+      io.in.ready := !full
+      io.out.valid := full
+      io.out.bits := RegNext(io.in.bits)
+    }){c =>
+      c.io.in.initSource().setSourceClock(c.clock)
+      c.io.out.initSink().setSinkClock(c.clock)
+      c.io.in.enqueue(9.U)
+      c.io.out.expectDequeue((9.U))
+      parallel(
+        c.io.in.enqueueSeq(Seq(5.U, 2.U)),
+        c.io.out.expectDequeueSeq(Seq(5.U, 2.U))
+      )
+    }
+  }
+
 }

--- a/src/test/scala/chisel3/tests/QueueTest.scala
+++ b/src/test/scala/chisel3/tests/QueueTest.scala
@@ -66,16 +66,10 @@ class QueueTest extends FlatSpec with ChiselScalatestTester {
         val in = Flipped(Irrevocable(UInt(8.W)))
         val out = Irrevocable(UInt(8.W))
       })
-      val full = RegInit(false.B)
-      when(io.in.fire()){ full := true.B }.elsewhen(io.out.fire()){ full := false.B }
-      io.in.ready := !full
-      io.out.valid := full
-      io.out.bits := RegNext(io.in.bits)
+      io.out <> Queue(io.in)
     }){c =>
       c.io.in.initSource().setSourceClock(c.clock)
       c.io.out.initSink().setSinkClock(c.clock)
-      c.io.in.enqueue(9.U)
-      c.io.out.expectDequeue((9.U))
       parallel(
         c.io.in.enqueueSeq(Seq(5.U, 2.U)),
         c.io.out.expectDequeueSeq(Seq(5.U, 2.U))


### PR DESCRIPTION
Signed-off-by: shuyun <shuyunjia@outlook.com>

issue related: #89

This commit is to: 
1. support enqueue/dequeue of IrrevocableIO
2. add implicit convert of IrrevocableIO to ReadyValidIO