### PR TITLE
Fix missing Scaladoc parenthesis

### DIFF
--- a/src/main/scala/chisel3/tester/ChiselScalatestTester.scala
+++ b/src/main/scala/chisel3/tester/ChiselScalatestTester.scala
@@ -79,7 +79,7 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
     *
     * For example:
     * {{{
-    *   test(new TestModule).withAnnotations(Seq(WriteVcdAnnotation) { c =>
+    *   test(new TestModule).withAnnotations(Seq(WriteVcdAnnotation)) { c =>
     *     // body of the unit test
     *   }
     * }}}


### PR DESCRIPTION
This adds a missing closing parenthesis in the Scaladoc for `ChiselScalatestTester`.