### PR TITLE
Re-add -DwriteVcd=1 feature

### DIFF
--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -8,7 +8,7 @@ import chisel3.MultiIOModule
 import firrtl.AnnotationSeq
 import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
-import treadle.WriteVcdAnnotation  // TODO this shouldn't be treadle-specific, but this feature is important
+import internal.WriteVcdAnnotation
 
 import scala.util.DynamicVariable
 
@@ -19,13 +19,11 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
     }
 
     def apply(testFn: T => Unit): Unit = {
-      val newAnnos = addDefaultTargetDir(getTestName, annotationSeq)
-      val withVcdAnnos = if (scalaTestContext.value.get.configMap.contains("writeVcd")) {
-        AnnotationSeq(newAnnos ++ Seq(WriteVcdAnnotation))
-      } else {
-        newAnnos
+      var newAnnos = addDefaultTargetDir(getTestName, annotationSeq)
+      if (scalaTestContext.value.get.configMap.contains("writeVcd")) {
+        newAnnos = newAnnos ++ Seq(WriteVcdAnnotation)
       }
-      runTest(defaults.createDefaultTester(dutGen, withVcdAnnos))(testFn)
+      runTest(defaults.createDefaultTester(dutGen, newAnnos))(testFn)
     }
     // TODO: in the future, allow reset and re-use of a compiled design to avoid recompilation cost per test
 

--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -8,6 +8,7 @@ import chisel3.MultiIOModule
 import firrtl.AnnotationSeq
 import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
+import treadle.WriteVcdAnnotation  // TODO this shouldn't be treadle-specific, but this feature is important
 
 import scala.util.DynamicVariable
 
@@ -19,7 +20,12 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
 
     def apply(testFn: T => Unit): Unit = {
       val newAnnos = addDefaultTargetDir(getTestName, annotationSeq)
-      runTest(defaults.createDefaultTester(dutGen, newAnnos))(testFn)
+      val withVcdAnnos = if (scalaTestContext.value.get.configMap.contains("writeVcd")) {
+        AnnotationSeq(newAnnos ++ Seq(WriteVcdAnnotation))
+      } else {
+        newAnnos
+      }
+      runTest(defaults.createDefaultTester(dutGen, withVcdAnnos))(testFn)
     }
     // TODO: in the future, allow reset and re-use of a compiled design to avoid recompilation cost per test
 


### PR DESCRIPTION
Was somehow removed in the stage/phase refactor in https://github.com/ucb-bar/chisel-testers2/commit/cbfe5b647e0baf1b5e4923109974e757d3e55059 - not sure if intentional. But this adds it back.

Tested with both treadle and Verilator.