### PR TITLE
ChiselEnum support

### DIFF
--- a/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
@@ -61,7 +61,7 @@ extends BackendInstance[T] with ThreadedBackend[T] {
     a > 0
   }
 
-  override def pokeBits(signal: Bits, value: BigInt): Unit = {
+  override def pokeBits(signal: Data, value: BigInt): Unit = {
     doPoke(signal, value, new Throwable)
     if (tester.peek(dataNames(signal)) != value) {
       idleCycles.clear()
@@ -70,7 +70,7 @@ extends BackendInstance[T] with ThreadedBackend[T] {
     debugLog(s"${resolveName(signal)} <- $value")
   }
 
-  override def peekBits(signal: Bits, stale: Boolean): BigInt = {
+  override def peekBits(signal: Data, stale: Boolean): BigInt = {
     require(!stale, "Stale peek not yet implemented")
 
     doPeek(signal, new Throwable)
@@ -79,7 +79,7 @@ extends BackendInstance[T] with ThreadedBackend[T] {
     a
   }
 
-  override def expectBits(signal: Bits, value: BigInt, message: Option[String], stale: Boolean): Unit = {
+  override def expectBits(signal: Data, value: BigInt, message: Option[String], stale: Boolean): Unit = {
     require(!stale, "Stale peek not yet implemented")
 
     debugLog(s"${resolveName(signal)} ?> $value")

--- a/src/main/scala/chiseltest/internal/BackendInterface.scala
+++ b/src/main/scala/chiseltest/internal/BackendInterface.scala
@@ -41,15 +41,15 @@ trait BackendInterface {
   /** Writes a value to a writable wire.
     * Throws an exception if write is not writable.
     */
-  def pokeBits(signal: Bits, value: BigInt): Unit
+  def pokeBits(signal: Data, value: BigInt): Unit
 
   /** Returns the current value on a wire.
     * If stale is true, returns the current combinational value (after previous pokes have taken effect).
     * If stale is false, returns the value at the beginning of the current cycle.
     */
-  def peekBits(signal: Bits, stale: Boolean): BigInt
+  def peekBits(signal: Data, stale: Boolean): BigInt
 
-  def expectBits(signal: Bits, value: BigInt, message: Option[String], stale: Boolean): Unit
+  def expectBits(signal: Data, value: BigInt, message: Option[String], stale: Boolean): Unit
 
   /**
    * Sets the timeout of the clock: the number of cycles the clock can advance without

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
@@ -79,7 +79,7 @@ class VerilatorBackend[T <: MultiIOModule](
     a > 0
   }
 
-  override def pokeBits(signal: Bits, value: BigInt): Unit = {
+  override def pokeBits(signal: Data, value: BigInt): Unit = {
     doPoke(signal, value, new Throwable)
     val dataName = dataNames(signal)
     if (simApiInterface.peek(dataName).get != value) {
@@ -89,7 +89,7 @@ class VerilatorBackend[T <: MultiIOModule](
     debugLog(s"${resolveName(signal)} <- $value")
   }
 
-  override def peekBits(signal: Bits, stale: Boolean): BigInt = {
+  override def peekBits(signal: Data, stale: Boolean): BigInt = {
     require(!stale, "Stale peek not yet implemented")
 
     doPeek(signal, new Throwable)
@@ -111,7 +111,7 @@ class VerilatorBackend[T <: MultiIOModule](
     }
   }
 
-  override def expectBits(signal: Bits,
+  override def expectBits(signal: Data,
                           value: BigInt,
                           message: Option[String],
                           stale: Boolean): Unit = {

--- a/src/test/scala/chiseltest/tests/ChiselEnumTest.scala
+++ b/src/test/scala/chiseltest/tests/ChiselEnumTest.scala
@@ -1,0 +1,68 @@
+package chiseltest.tests
+
+import org.scalatest._
+
+import chisel3._
+import chiseltest._
+import chisel3.experimental.ChiselEnum
+
+class ChiselEnumTest extends FlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2"
+
+  object EnumExample extends ChiselEnum {
+    val e0, e1, e2 = Value
+  }
+
+  it should "poke enums with enum literals" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val in = Input(EnumExample())
+        val out = Output(UInt(2.W))
+      })
+      io.out := io.in.asUInt()
+    }) { c =>
+      c.io.in.poke(EnumExample.e0)
+      c.io.out.expect(0.U)
+      c.io.in.poke(EnumExample.e1)
+      c.io.out.expect(1.U)
+    }
+  }
+
+  it should "expect enums with enum literals" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val in = Input(UInt(2.W))
+        val out = Output(EnumExample())
+      })
+      io.out := io.in.asTypeOf(chiselTypeOf(io.out))
+    }) { c =>
+      c.io.in.poke(0.U)
+      c.io.out.expect(EnumExample.e0)
+      c.io.in.poke(1.U)
+      c.io.out.expect(EnumExample.e1)
+    }
+  }
+
+  ignore should "peek enum literals" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val in = Input(UInt(2.W))
+        val out = Output(EnumExample())
+      })
+      io.out := io.in.asTypeOf(chiselTypeOf(io.out))
+    }) { c =>
+      c.io.in.poke(0.U)
+      val output = c.io.out.peek()
+      output.litValue should be (0)
+      output.getClass() should be (c.io.out.getClass())
+    }
+  }
+
+  ignore should "roundtrip enum literals" in {
+    test(new PassthroughModule(EnumExample())) { c =>
+      c.in.poke(EnumExample.e1)
+      c.in.poke(c.out.peek())
+      c.out.expect(EnumExample.e0)
+    }
+  }
+}


### PR DESCRIPTION
Partial for #12

`poke` and `expect` work as expected. `peek` does not, because I don't think there's a programmatic literal construction API for ChiselEnum.

`pokeBits` has been expanded to Data in general. I'm not sure if this is the right solution (alternatively, ChiselEnum can be Bits - because it's very Bits-like). While expanding the pokeBits API makes it work on things like Clock (and eliminates the need for a pokeClock API) it becomes less type safe (should pokeBits be allowed on Bundle? probably not - that is handled at a higher level). Alternatives include pokeElement (but that wouldn't work on Analog), or overloading pokeBits to support Bits, Clock, and ChiselEnum.