### PR TITLE
Make scala-steward ignore edu.berkeley.cs deps

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [ { groupId = "edu.berkeley.cs" } ]


### PR DESCRIPTION
My reading of the scala-steward documentation means that adding this file will tel scala-steward to ignore any dependencies coming from `edu.berkeley.cs`. This should be the minimal change to stop the snapshot updating.

Completely untested, though...