### PR TITLE
Adds the ability to invoke tests with command line arguments

### DIFF
--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -19,20 +19,16 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
     def getTestName: String = {
       sanitizeFileName(scalaTestContext.value.get.name)
     }
-    def apply(testFn: T => Unit): Unit = {
-      val finalAnnos = updateAnnotations((new ChiselTestShell).parse(flags) ++ annotationSeq)
-      runTest(defaults.createDefaultTester(dutGen, finalAnnos))(testFn)
-    }
 
-    /** Add a targetDir if none has been specified, check the context
-      * to see if a writeVcd should be added
-      */
-    def updateAnnotations(annotationSeq: AnnotationSeq): AnnotationSeq = {
-      var newAnnos = addDefaultTargetDir(getTestName, annotationSeq)
-      if (scalaTestContext.value.get.configMap.contains("writeVcd")) {
-        newAnnos = newAnnos ++ Seq(WriteVcdAnnotation)
-      }
-      newAnnos
+    def apply(testFn: T => Unit): Unit = {
+      val finalAnnos = addDefaultTargetDir(getTestName, (new ChiselTestShell).parse(flags) ++ annotationSeq) ++
+        (if (scalaTestContext.value.get.configMap.contains("writeVcd")) {
+          Seq(WriteVcdAnnotation)
+        } else {
+          Seq.empty
+        })
+
+      runTest(defaults.createDefaultTester(dutGen, finalAnnos))(testFn)
     }
 
     def run(testFn: T => Unit, annotations: AnnotationSeq): Unit = {

--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -9,6 +9,7 @@ import firrtl.AnnotationSeq
 import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
 import internal.WriteVcdAnnotation
+import logger.Logger
 
 import scala.util.DynamicVariable
 
@@ -36,7 +37,9 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
       if (scalaTestContext.value.get.configMap.contains("writeVcd")) {
         newAnnos = newAnnos ++ Seq(WriteVcdAnnotation)
       }
-      runTest(defaults.createDefaultTester(dutGen, newAnnos))(testFn)
+      Logger.makeScope(newAnnos) {
+        runTest(defaults.createDefaultTester(dutGen, newAnnos))(testFn)
+      }
     }
 
   }
@@ -53,7 +56,9 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
       if (scalaTestContext.value.get.configMap.contains("writeVcd")) {
         newAnnos = newAnnos ++ Seq(WriteVcdAnnotation)
       }
-      runTest(defaults.createDefaultTester(dutGen, newAnnos))(testFn)
+      Logger.makeScope(newAnnos) {
+        runTest(defaults.createDefaultTester(dutGen, newAnnos))(testFn)
+      }
     }
   }
 

--- a/src/main/scala/chiseltest/experimental/ChiselTestShell.scala
+++ b/src/main/scala/chiseltest/experimental/ChiselTestShell.scala
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Regents of the University of California (Regents)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package chiseltest.experimental
+
+import chisel3.stage.ChiselCli
+import chiseltest.internal.{TreadleBackendAnnotation, VerilatorBackendAnnotation, WriteVcdAnnotation}
+import firrtl.options.Shell
+import firrtl.stage.FirrtlCli
+
+trait ChiselTestCli extends ChiselCli with FirrtlCli {
+  this: Shell =>
+
+  parser.note("ChiselTest Options")
+
+  Seq(
+    VerilatorBackendAnnotation,
+    TreadleBackendAnnotation,
+    WriteVcdAnnotation
+  ).foreach(_.addOptions(parser))
+}
+
+class ChiselTestShell extends Shell("ChiselTest") with ChiselTestCli

--- a/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
@@ -21,13 +21,6 @@ package object TestOptionBuilder {
       new x.outer.TestBuilder[T](x.dutGen, Seq.empty, flags)
     }
 
-    def withAnnotationsAndFlags(
-                                 annotationSeq: AnnotationSeq,
-                                 flags: Array[String]
-                               ): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, annotationSeq, flags)
-    }
-
     @deprecated("Use withAnnotations instead", "a long time ago")
     def withExecOptions(manager: ExecutionOptionsManager with HasTreadleSuite): ChiselScalatestTester#TestBuilder[T] = {
       val annos = manager.toAnnotationSeq.map {

--- a/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
@@ -14,11 +14,18 @@ import firrtl.{
 package object TestOptionBuilder {
   implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
     def withAnnotations(annotationSeq: AnnotationSeq): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.AnnotatedTestBuilder[T](x.dutGen, annotationSeq)
+      new x.outer.TestBuilder[T](x.dutGen, annotationSeq, Array.empty)
     }
 
     def withFlags(flags: Array[String]): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.FlaggedTestBuilder[T](x.dutGen, flags)
+      new x.outer.TestBuilder[T](x.dutGen, Seq.empty, flags)
+    }
+
+    def withAnnotationsAndFlags(
+                                 annotationSeq: AnnotationSeq,
+                                 flags: Array[String]
+                               ): ChiselScalatestTester#TestBuilder[T] = {
+      new x.outer.TestBuilder[T](x.dutGen, annotationSeq, flags)
     }
 
     @deprecated("Use withAnnotations instead", "a long time ago")
@@ -32,12 +39,12 @@ package object TestOptionBuilder {
         case anno => anno
       }
 
-      new x.outer.AnnotatedTestBuilder[T](x.dutGen, annos)
+      new x.outer.TestBuilder[T](x.dutGen, annos, Array.empty)
     }
 
     @deprecated("Use withAnnotations instead", "a long time ago")
     def withTesterOptions(opt: TesterOptions): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.AnnotatedTestBuilder[T](x.dutGen, opt.toAnnotations)
+      new x.outer.TestBuilder[T](x.dutGen, opt.toAnnotations, Array.empty)
     }
   }
 }

--- a/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
@@ -14,7 +14,11 @@ import firrtl.{
 package object TestOptionBuilder {
   implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
     def withAnnotations(annotationSeq: AnnotationSeq): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, annotationSeq)
+      new x.outer.AnnotatedTestBuilder[T](x.dutGen, annotationSeq)
+    }
+
+    def withFlags(flags: Array[String]): ChiselScalatestTester#TestBuilder[T] = {
+      new x.outer.FlaggedTestBuilder[T](x.dutGen, flags)
     }
 
     @deprecated("Use withAnnotations instead", "a long time ago")
@@ -28,12 +32,12 @@ package object TestOptionBuilder {
         case anno => anno
       }
 
-      new x.outer.TestBuilder[T](x.dutGen, annos)
+      new x.outer.AnnotatedTestBuilder[T](x.dutGen, annos)
     }
 
     @deprecated("Use withAnnotations instead", "a long time ago")
     def withTesterOptions(opt: TesterOptions): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, opt.toAnnotations)
+      new x.outer.AnnotatedTestBuilder[T](x.dutGen, opt.toAnnotations)
     }
   }
 }

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
@@ -36,7 +36,7 @@ class VerilatorBasicTests extends FlatSpec with ChiselScalatestTester with Match
 
   it should "fail with user-defined message" in {
     intercept[exceptions.TestFailedException] {
-      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+      test(new StaticModule(42.U)).withFlags(Array("--t-use-verilator")) { c =>
         c.out.expect(0.U, "user-defined failure message =(")
       }
     }.getMessage should include ("user-defined failure message =(")

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
@@ -36,7 +36,7 @@ class VerilatorBasicTests extends FlatSpec with ChiselScalatestTester with Match
 
   it should "fail with user-defined message" in {
     intercept[exceptions.TestFailedException] {
-      test(new StaticModule(42.U)).withFlags(Array("--t-use-verilator")) { c =>
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
         c.out.expect(0.U, "user-defined failure message =(")
       }
     }.getMessage should include ("user-defined failure message =(")

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -11,7 +11,7 @@ import logger.{LazyLogging, Logger}
 import org.scalatest._
 import treadle.{VerboseAnnotation, WriteVcdAnnotation}
 
-class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matchers with LazyLogging {
+class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   it should "write vcd output when passing in a WriteVcdAnnotation" in {

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -7,7 +7,6 @@ import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.experimental.sanitizeFileName
 import firrtl.stage.OutputFileAnnotation
-import logger.{LazyLogging, Logger}
 import org.scalatest._
 import treadle.{VerboseAnnotation, WriteVcdAnnotation}
 

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -54,19 +54,20 @@ class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matche
     output.contains("clock/prev") should be (true)
   }
 
-  class LogsSomething extends MultiIOModule with LazyLogging {
+  class DummyModule extends MultiIOModule with LazyLogging {
     val out = IO(Output(UInt(16.W)))
     out := 42.U
   }
 
   def testCliFlagging(expectedResult: Boolean, flags: Array[String]): Unit = {
     val loggingCaptor = new Logger.OutputCaptor
-    test(new LogsSomething {}).withFlags(flags) { c =>
+    test(new DummyModule {}).withFlags(flags) { c =>
         Logger.setOutput(loggingCaptor.printStream)
 
         c.out.expect(42.U)
         logger.info("Testing module LogsSomething")
       }
+    println(loggingCaptor.getOutputAsString)
     loggingCaptor.getOutputAsString.contains("Testing module LogsSomething") should be(expectedResult)
   }
 

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -60,7 +60,7 @@ class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matche
       targetDir.delete()
     }
     test(new MultiIOModule() {})
-      .withAnnotationsAndFlags(annotations, Array("--target-dir", targetDirName)) { c =>
+      .withAnnotations(annotations).withFlags(Array("--target-dir", targetDirName)) { c =>
       targetDir.exists() should be (true)
       val firrtlFile = new File(targetDir + File.separator + "wheaton.lo.fir")
       firrtlFile.exists() should be (true)


### PR DESCRIPTION
The major case for this is that command line arguments have a better discovery mechanism through `--help`

- Add ChiseTestShell that can parse command line arguments and produce corresponding annotations
- Adds helper method `withFlags` that is the equivalent for CLI flags as `withAnnotations`
- Slight refactoring of TestBuilder to be a trait with two implementations AnnotatedTestBuilder and FlaggedTestBuilder
- Changed experimental basic verilator test to use this new way of selecting the verilator backend