### PR TITLE
Bug fix for verilator backend

### DIFF
--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -43,7 +43,8 @@ object VerilatorExecutive extends BackendExecutive {
     val targetDirFile = new File(targetDir)
 
     val generatorAnnotation = chisel3.stage.ChiselGeneratorAnnotation(dutGen)
-    val circuit = generatorAnnotation.elaborate.collect { case x: ChiselCircuitAnnotation => x }.head.circuit
+    val elaboratedAnno = (new chisel3.stage.phases.Elaborate).transform(annotationSeq :+ generatorAnnotation)
+    val circuit = elaboratedAnno.collect { case x: ChiselCircuitAnnotation => x }.head.circuit
     val dut = getTopModule(circuit).asInstanceOf[T]
 
     // Create the header files that verilator needs
@@ -57,8 +58,7 @@ object VerilatorExecutive extends BackendExecutive {
     // - TestCommandOverride
     // - CombinationalPath
     val compiledAnnotations = (new ChiselStage).run(
-      annotationSeq ++
-        Seq(generatorAnnotation, CompilerAnnotation(new VerilogCompiler()))
+      elaboratedAnno :+ CompilerAnnotation(new VerilogCompiler())
     )
 
     val cppHarnessFileName = s"${circuit.name}-harness.cpp"


### PR DESCRIPTION
Currently verilator backend runs `chisel3.stage.phases.Elaborate` twice, first one is generating circuit, second is generating verilog.
In first elaborate phase will leave `chisel3.internal.Builder` to a wrong state, which leads to second elaborate phase throw a exception "attempted to instantiate a Module, but nothing happened".