### PR TITLE
User-friendly hint when forgetting join after fork

### DIFF
--- a/src/main/scala/chiseltest/internal/ThreadedBackend.scala
+++ b/src/main/scala/chiseltest/internal/ThreadedBackend.scala
@@ -385,7 +385,7 @@ trait ThreadedBackend[T <: MultiIOModule] extends BackendInterface {
       }
       if (timescope.closedTime.isDefined) {  // if this timescope is closed, ensure there are no children
         if (overridingTimescopes.nonEmpty) {
-          throw new ThreadOrderDependentException(s"Non-enclosed timescopes")
+          throw new ThreadOrderDependentException(s"Non-enclosed timescopes detected. Did you forget to call join after fork?")
         }
       }
       if (overridingTimescopes.length > 1) {  // multiple overlapping pokes, is an error


### PR DESCRIPTION
"non-enclosed timescope" can be a pretty cryptic message from a user's perspective