### PR TITLE
Fix CI testing problem with OptionsPassingTest

### DIFF
--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -14,9 +14,7 @@ import scala.util.DynamicVariable
 
 trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvInterface { this: TestSuite =>
 
-  class TestBuilder[T <: MultiIOModule](val dutGen:        () => T,
-                                        val annotationSeq: AnnotationSeq,
-                                        val flags:         Array[String]) {
+  class TestBuilder[T <: MultiIOModule](val dutGen: () => T, val annotationSeq: AnnotationSeq, val flags: Array[String]) {
     def getTestName: String = {
       sanitizeFileName(scalaTestContext.value.get.name)
     }

--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -9,13 +9,14 @@ import firrtl.AnnotationSeq
 import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
 import internal.WriteVcdAnnotation
-import logger.Logger
 
 import scala.util.DynamicVariable
 
 trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvInterface { this: TestSuite =>
 
-  class TestBuilder[T <: MultiIOModule](val dutGen: () => T, annotationSeq: AnnotationSeq, flags: Array[String]) {
+  class TestBuilder[T <: MultiIOModule](val dutGen:        () => T,
+                                        val annotationSeq: AnnotationSeq,
+                                        val flags:         Array[String]) {
     def getTestName: String = {
       sanitizeFileName(scalaTestContext.value.get.name)
     }
@@ -87,7 +88,8 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
     *   }
     * }}}
     *
-    * If you need to add options to this unit test you can tack on a .withAnnotations modifier
+    * If you need to add options to this unit test you can tack on .withAnnotations modifier
+    * or a .withFlags modifier. These modifiers can be used together.
     * You must add `import chisel3.tester.experimental.TestOptionBuilder._` to use .withAnnotations
     *
     * For example:

--- a/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
@@ -14,11 +14,11 @@ import firrtl.{
 package object TestOptionBuilder {
   implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
     def withAnnotations(annotationSeq: AnnotationSeq): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, annotationSeq, Array.empty)
+      new x.outer.TestBuilder[T](x.dutGen, x.annotationSeq ++ annotationSeq, x.flags)
     }
 
     def withFlags(flags: Array[String]): ChiselScalatestTester#TestBuilder[T] = {
-      new x.outer.TestBuilder[T](x.dutGen, Seq.empty, flags)
+      new x.outer.TestBuilder[T](x.dutGen, x.annotationSeq, x.flags ++ flags)
     }
 
     @deprecated("Use withAnnotations instead", "a long time ago")

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -3,9 +3,11 @@ package chiseltest.tests
 import java.io.{ByteArrayOutputStream, File, PrintStream}
 
 import chisel3._
+import chisel3.stage.ChiselOutputFileAnnotation
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.experimental.sanitizeFileName
+import firrtl.options.OutputAnnotationFileAnnotation
 import firrtl.stage.OutputFileAnnotation
 import org.scalatest._
 import treadle.{VerboseAnnotation, WriteVcdAnnotation}
@@ -53,15 +55,21 @@ class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matche
 
   it should "allow specifying configuration options using annotations and CLI style flags" in {
     val targetDirName = "test_run_dir/overridden_dir_2"
-    val annotations = Seq(OutputFileAnnotation("wheaton"))
+    val fileBaseName = "wheaton"
+    val annotations = Seq(
+      ChiselOutputFileAnnotation(fileBaseName),
+      OutputFileAnnotation(fileBaseName),
+      OutputAnnotationFileAnnotation(fileBaseName)
+    )
     val targetDir = new File(targetDirName)
     if(targetDir.exists()) {
       targetDir.delete()
     }
     test(new MultiIOModule() {})
-      .withAnnotations(annotations).withFlags(Array("--target-dir", targetDirName)) { c =>
+      .withAnnotations(annotations)
+      .withFlags(Array("--target-dir", targetDirName)) { c =>
       targetDir.exists() should be (true)
-      val firrtlFile = new File(targetDir + File.separator + "wheaton.lo.fir")
+      val firrtlFile = new File(targetDir + File.separator + s"$fileBaseName.lo.fir")
       firrtlFile.exists() should be (true)
     }
   }


### PR DESCRIPTION
- Calls to .withFlags and .withAnnotations now keeps values from previous invocations
- removed unused logger import
- made flags and annos vals in TestBuilder so they can be retained for subsequent .with* invocations
- updated scaladoc on `def test` to mention withFlags
- Fixed `it should "allow specifying configuration options using annotations and CLI style flags"` test
  - It needed all three output file annotations to make a test run directory with consistently named files