### PR TITLE
Create VCS backend for testers2

### DIFF
--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -5,10 +5,10 @@ package chiseltest
 import chiseltest.internal._
 import chiseltest.experimental.{ChiselTestShell, sanitizeFileName}
 import chisel3.MultiIOModule
+import chiseltest.internal.WriteVcdAnnotation
 import firrtl.AnnotationSeq
 import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
-import internal.WriteVcdAnnotation
 
 import scala.util.DynamicVariable
 

--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -2,10 +2,11 @@
 
 package chiseltest.internal
 
+import chisel3.MultiIOModule
 import chiseltest.backends.BackendExecutive
 import chiseltest.backends.treadle.TreadleExecutive
+import chiseltest.legacy.backends.vcs.VcsExecutive
 import chiseltest.legacy.backends.verilator.VerilatorExecutive
-import chisel3.MultiIOModule
 import firrtl.AnnotationSeq
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
 import firrtl.options.{HasShellOptions, ShellOption, Unserializable}
@@ -61,6 +62,7 @@ case object TreadleBackendAnnotation extends BackendAnnotation {
     )
   )
 }
+
 case object VerilatorBackendAnnotation extends BackendAnnotation {
   val executive: BackendExecutive = VerilatorExecutive
 
@@ -69,6 +71,18 @@ case object VerilatorBackendAnnotation extends BackendAnnotation {
       longOption = "t-use-verilator",
       toAnnotationSeq = _ => Seq(VerilatorBackendAnnotation),
       helpText = "direct tester to use verilator backend"
+    )
+  )
+}
+
+case object VcsBackendAnnotation extends BackendAnnotation {
+  val executive: BackendExecutive = VcsExecutive
+
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "t-use-vcs",
+      toAnnotationSeq = _ => Seq(VerilatorBackendAnnotation),
+      helpText = "direct tester to use VCS backend"
     )
   )
 }

--- a/src/main/scala/chiseltest/legacy/backends/vcs/CopyVpiFiles.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/CopyVpiFiles.scala
@@ -1,0 +1,34 @@
+package chiseltest.legacy.backends.vcs
+
+import java.io.{File, IOException}
+import java.nio.file.{FileAlreadyExistsException, Files, Paths}
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+/**
+  * Copies the necessary header files used for verilator compilation to the specified destination folder
+  */
+object CopyVpiFiles {
+  def apply(destinationDirPath: String): Unit = {
+    new File(destinationDirPath).mkdirs()
+    val simApiHFilePath = Paths.get(destinationDirPath + "/sim_api.h")
+    val vpiHFilePath = Paths.get(destinationDirPath + "/vpi.h")
+    val vpiCppFilePath = Paths.get(destinationDirPath + "/vpi.cpp")
+    val vpiTabFilePath = Paths.get(destinationDirPath + "/vpi.tab")
+
+    for(fileName <- Seq(simApiHFilePath, vpiHFilePath, vpiCppFilePath, vpiTabFilePath)) {
+      try {
+        Files.createFile(fileName)
+      } catch {
+        case _: FileAlreadyExistsException =>
+        case x: IOException =>
+          System.err.format("createFile error: %s%n", x)
+      }
+    }
+
+    val resourceDir = "/chisel3/tester/legacy/backends/verilator"
+    Files.copy(getClass.getResourceAsStream(s"$resourceDir/sim_api.h"), simApiHFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream(s"$resourceDir/vpi.h"), vpiHFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream(s"$resourceDir/vpi.cpp"), vpiCppFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream(s"$resourceDir/vpi.tab"), vpiTabFilePath, REPLACE_EXISTING)
+  }
+}

--- a/src/main/scala/chiseltest/legacy/backends/vcs/GenVcsVerilogHarness.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/GenVcsVerilogHarness.scala
@@ -1,0 +1,112 @@
+package chiseltest.legacy.backends.vcs
+
+import java.io.Writer
+
+import chisel3._
+import chisel3.experimental.DataMirror
+import chiseltest.legacy.backends.verilator.getDataNames
+
+/**
+  * Generates the Module specific verilator harness cpp file for verilator compilation
+  */
+object GenVcsVerilogHarness {
+
+  def getPorts(dut: MultiIOModule, separator: String = "."): (Seq[(Element, String)], Seq[(Element, String)]) = {
+    getDataNames(dut, separator) partition { case (e, _) => DataMirror.directionOf(e) == ActualDirection.Input }
+  }
+
+  // getPorts() is going to return names prefixed with the dut name.
+  // These don't correspond to code currently generated for verilog modules,
+  //  so we have to strip the dut name prefix (and the delimiter) from the name.
+  // We tell getPorts() to use "_" as the delimiter to simplify the replacement regexp.
+  def fixNames(dutName: String, portSeq: (Seq[(Element, String)], Seq[(Element, String)])): (Seq[(Element, String)], Seq[(Element, String)]) = {
+    val replaceRegexp = ("^" + dutName + "_").r
+    (
+      portSeq._1 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))},
+      portSeq._2 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))}
+    )
+  }
+
+  def apply(dut: MultiIOModule, writer: Writer, vpdFilePath: String, isGateLevel: Boolean = false) {
+    val dutName = dut.name
+    // getPorts() is going to return names prefixed with the dut name.
+    // These don't correspond to code currently generated for verilog modules,
+    //  so we have to strip the dut name prefix (and the delimiter) from the name.
+    // We tell getPorts() to use "_" as the delimiter to simplify the replacement regexp.
+    def fixNames(portSeq: (Seq[(Element, String)], Seq[(Element, String)])): (Seq[(Element, String)], Seq[(Element, String)]) = {
+      val replaceRegexp = ("^" + dutName + "_").r
+      (
+        portSeq._1 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))},
+        portSeq._2 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))}
+      )
+    }
+
+    val (inputs, outputs) = fixNames(getPorts(dut, "_"))
+
+    writer write "module test;\n"
+    writer write "  reg clock = 1;\n"
+    writer write "  reg reset = 1;\n"
+    val delay = if (isGateLevel) "#0.1" else ""
+    inputs foreach { case (node, name) =>
+      writer write s"  reg[${node.getWidth-1}:0] $name = 0;\n"
+      writer write s"  wire[${node.getWidth-1}:0] ${name}_delay;\n"
+      writer write s"  assign $delay ${name}_delay = $name;\n"
+    }
+    outputs foreach { case (node, name) =>
+      writer write s"  wire[${node.getWidth-1}:0] ${name}_delay;\n"
+      writer write s"  wire[${node.getWidth-1}:0] $name;\n"
+      writer write s"  assign $delay $name = ${name}_delay;\n"
+    }
+
+    writer write "  always #`CLOCK_PERIOD clock = ~clock;\n"
+    writer write "  reg vcdon = 0;\n"
+    writer write "  reg [1023:0] vcdfile = 0;\n"
+    writer write "  reg [1023:0] vpdfile = 0;\n"
+
+    writer write "\n  /*** DUT instantiation ***/\n"
+    writer write s"  $dutName $dutName(\n"
+    writer write "    .clock(clock),\n"
+    writer write "    .reset(reset),\n"
+    writer write ((inputs ++ outputs).map(_._2) map (name => s"    .$name(${name}_delay)") mkString ",\n")
+    writer write "  );\n\n"
+
+    writer write "  initial begin\n"
+    writer write "    $init_rsts(reset);\n"
+    writer write "    $init_ins(%s);\n".format(inputs.map(_._2) mkString ", ")
+    writer write "    $init_outs(%s);\n".format(outputs.map(_._2) mkString ", ")
+    writer write "    $init_sigs(%s);\n".format(dutName)
+    writer write "    /*** VCD & VPD dump ***/\n"
+    writer write "    if ($value$plusargs(\"vcdfile=%s\", vcdfile)) begin\n"
+    writer write "      $dumpfile(vcdfile);\n"
+    writer write "      $dumpvars(0, %s);\n".format(dutName)
+    writer write "      $dumpoff;\n"
+    writer write "      vcdon = 0;\n"
+    writer write "    end\n"
+    writer write "    if ($value$plusargs(\"waveform=%s\", vpdfile)) begin\n"
+    writer write "      $vcdplusfile(vpdfile);\n"
+    writer write "    end else begin\n"
+    writer write "      $vcdplusfile(\"%s\");\n".format(vpdFilePath)
+    writer write "    end\n"
+    writer write "    if ($test$plusargs(\"vpdmem\")) begin\n"
+    writer write "      $vcdplusmemon;\n"
+    writer write "    end\n"
+    writer write "    $vcdpluson(0);\n"
+    writer write "  end\n\n"
+
+    writer write "  always @(%s clock) begin\n".format(if (isGateLevel) "posedge" else "negedge")
+    writer write "    if (vcdfile && reset) begin\n"
+    writer write "      $dumpoff;\n"
+    writer write "      vcdon = 0;\n"
+    writer write "    end\n"
+    writer write "    else if (vcdfile && !vcdon) begin\n"
+    writer write "      $dumpon;\n"
+    writer write "      vcdon = 1;\n"
+    writer write "    end\n"
+    writer write "    %s $tick();\n".format(if (isGateLevel) "#0.05" else "")
+    writer write "    $vcdplusflush;\n"
+    writer write "  end\n\n"
+    writer write "endmodule\n"
+    writer.close()
+  }
+}
+

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsAnnotations.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsAnnotations.scala
@@ -1,0 +1,97 @@
+// See LICENSE for license details.
+
+package chiseltest.legacy.backends.vcs
+
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.options.{HasShellOptions, ShellOption, Unserializable}
+
+trait VcsOption extends NoTargetAnnotation with Unserializable {
+  this: Annotation =>
+}
+trait VcsOptionObject extends VcsOption with HasShellOptions
+
+/** Used to suppress verilator simulation vcd output.
+  */
+case object SuppressVcsVcd extends VcsOptionObject {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "t-random-seed",
+      toAnnotationSeq = _ => Seq(SuppressVcsVcd),
+      helpText = "sets the seed for Treadle's random number generator"
+    )
+  )
+}
+
+/** A sequence string flags to add to verilator command line
+  *
+  * @param flags additional flags
+  */
+case class VcsFlags(flags: Seq[String]) extends VcsOption
+
+/** CLI builder for VcsFlags
+  */
+case object VcsFlags extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "t-verilator-flags",
+      toAnnotationSeq = (flags: String) =>
+        Seq(VcsFlags(flags.split(" +"))),
+      helpText = "additional flags to pass to the verilator program"
+    )
+  )
+}
+
+/** A sequence string flags to add to verilator command line
+  *
+  * @param flags additional flags
+  */
+case class VcsCFlags(flags: Seq[String]) extends VcsOption
+
+/** CLI builder for VcsCFlags
+  */
+case object VcsCFlags extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "t-verilator-flags",
+      toAnnotationSeq = (flags: String) =>
+        Seq(VcsCFlags(flags.split(" +"))),
+      helpText = "additional flags to pass to the c++ compiler"
+    )
+  )
+}
+
+/** A string specifying a file containing regex edits for verilator command line
+  *
+  * @param flags additional flags
+  */
+case class CommandEditsFile(flags: String) extends VcsOption
+
+/** CLI builder for CommandEditsFile
+  */
+case object CommandEditsFile extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "t-command-edits-file",
+      toAnnotationSeq = (flags: String) => Seq(CommandEditsFile(flags)),
+      helpText = "file of regex edits to apply to verilator program string"
+    )
+  )
+}
+
+/** A string specifying a file containing regex edits for verilator command line
+  *
+  * @param flags additional flags
+  */
+case class TestCommandOverride(flags: String) extends VcsOption
+
+/** CLI builder for TestCommandOverride
+  */
+case object TestCommandOverride extends HasShellOptions {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[String](
+      longOption = "t-command-edits-file",
+      toAnnotationSeq = (flags: String) => Seq(TestCommandOverride(flags)),
+      helpText = "file of regex edits to apply to verilator program string"
+    )
+  )
+}

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
@@ -1,0 +1,22 @@
+// See LICENSE for license details.
+
+package chiseltest.legacy.backends.vcs
+
+import chisel3._
+import chiseltest.legacy.backends.verilator.VerilatorBackend
+
+/** Supports Backend and Threaded traits for ex
+  *
+  * @param dut                  the device under test
+  * @param dataNames            basically the IO ports
+  * @param combinationalPaths   paths detected by CheckCombLoop
+  * @param command              the simulation program to execute
+  * @tparam T                   the dut's type
+  */
+class VcsBackend[T <: MultiIOModule](
+  dut: T,
+  dataNames: Map[Data, String],
+  combinationalPaths: Map[Data, Set[Data]],
+  command: Seq[String]
+) extends VerilatorBackend(dut, dataNames, combinationalPaths, command)
+

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
@@ -1,0 +1,126 @@
+package chiseltest.legacy.backends.vcs
+
+import java.io.{File, FileWriter}
+
+import chisel3._
+import chisel3.experimental.DataMirror
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
+import chiseltest.internal.BackendInstance
+import chiseltest.backends.BackendExecutive
+import firrtl.annotations.{DeletedAnnotation, ReferenceTarget}
+import firrtl.stage.CompilerAnnotation
+import firrtl.transforms.CombinationalPath
+
+object VcsExecutive extends BackendExecutive {
+  import firrtl._
+
+  /** Verilator wants to have module name prefix except for
+    * default reset and clock
+    *
+    * @param component signal name to be mapped into backend string form
+    * @return
+    */
+  def componentToName(component: ReferenceTarget): String = {
+    component.name match {
+      case "reset" => "reset"
+      case "clock" => "clock"
+      case _ =>
+        s"${component.module}.${component.name}"
+    }
+  }
+
+  def start[T <: MultiIOModule](
+    dutGen: () => T,
+    annotationSeq: AnnotationSeq
+  ): BackendInstance[T] = {
+
+    // Force a cleanup: long SBT runs tend to fail with memory issues
+    System.gc()
+
+    val targetDir = annotationSeq.collectFirst {
+      case TargetDirAnnotation(t) => t
+    }.get
+    val targetDirFile = new File(targetDir)
+
+    val generatorAnnotation = chisel3.stage.ChiselGeneratorAnnotation(dutGen)
+    val circuit = generatorAnnotation.elaborate
+      .collect { case x: ChiselCircuitAnnotation => x }
+      .head
+      .circuit
+    val dut = getTopModule(circuit).asInstanceOf[T]
+
+    // Generate the verilog file and some or all of the following annotations
+    // - OutputFileAnnotation
+    // - VerilatorFlagsAnnotation
+    // - VerilatorCFlagsAnnotation
+    // - CommandEditsFile
+    // - TestCommandOverride
+    // - CombinationalPath
+    //
+    // This run also creates the target dir and places the verilog in it
+
+    val compiledAnnotations = (new ChiselStage)
+      .run(
+        annotationSeq ++ Seq(
+          generatorAnnotation,
+          CompilerAnnotation(new VerilogCompiler())
+        )
+      )
+      .filterNot(_.isInstanceOf[DeletedAnnotation])
+
+    // Generate Harness
+    val vcsHarnessFileName = s"${circuit.name}-harness.v"
+    val vcsHarnessFile = new File(targetDir, vcsHarnessFileName)
+    val vpdFile = new File(targetDir, s"${circuit.name}.vpd")
+    CopyVpiFiles(targetDir.toString)
+
+    GenVcsVerilogHarness(dut, new FileWriter(vcsHarnessFile), vpdFile.toString)
+
+    val portNames = DataMirror
+      .modulePorts(dut)
+      .flatMap {
+        case (name, data) =>
+          getDataNames(name, data).toList.map {
+            case (p, "reset") => (p, "reset")
+            case (p, "clock") => (p, "clock")
+            case (p, n)       => (p, s"${circuit.name}.$n")
+            //          case (p, n) => (p, s"$n")
+          }
+      }
+      .toMap
+
+    val moreVcsFlags = compiledAnnotations
+      .collectFirst { case VcsFlags(flagSeq) => flagSeq }
+      .getOrElse(Seq())
+    val moreVcsCFlags = compiledAnnotations
+      .collectFirst { case VcsCFlags(flagSeq) => flagSeq }
+      .getOrElse(Seq())
+    val editCommands = compiledAnnotations.collectFirst {
+      case CommandEditsFile(fileName) => fileName
+    }.getOrElse("")
+
+    assert(
+      VerilogToVcs(
+        circuit.name,
+        targetDirFile,
+        new File(vcsHarnessFileName),
+        moreVcsFlags,
+        moreVcsCFlags,
+        editCommands
+      ).! == 0
+    )
+
+    val command = compiledAnnotations
+      .collectFirst[Seq[String]] {
+        case TestCommandOverride(f) => f.split(" +")
+      }
+      .getOrElse { Seq(new File(targetDir, circuit.name).toString) }
+
+    val paths = compiledAnnotations.collect { case c: CombinationalPath => c }
+
+    val pathsAsData =
+      combinationalPathsToData(dut, paths, portNames, componentToName)
+
+    new VcsBackend(dut, portNames, pathsAsData, command)
+  }
+}

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VerilogToVcs.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VerilogToVcs.scala
@@ -1,0 +1,96 @@
+package chiseltest.legacy.backends.vcs
+
+import chiseltest.legacy.backends.verilator.EditableBuildCSimulatorCommand
+import scala.sys.process._
+
+object VerilogToVcs extends EditableBuildCSimulatorCommand {
+  val prefix = "vcs-command-edit"
+  override def composeCommand(topModule: String,
+                              dir: java.io.File,
+                              flags: Seq[String],
+                              cFlags: Seq[String]): String = {
+    Seq("cd", dir.toString, "&&", "vcs") ++ flags mkString " "
+
+  }
+
+  def composeFlags(
+    topModule: String,
+    dir: java.io.File,
+    moreVcsFlags: Seq[String] = Seq.empty[String],
+    moreVcsCFlags: Seq[String] = Seq.empty[String]
+  ): (Seq[String], Seq[String]) = {
+
+    val ccFlags = Seq("-I$VCS_HOME/include", "-I$dir", "-fPIC", "-std=c++11") ++ moreVcsCFlags
+
+    val vcsFlags = Seq(
+      "-full64",
+      "-quiet",
+      "-timescale=1ns/1ps",
+      "-debug_pp",
+      s"-Mdir=$topModule.csrc",
+      "+v2k",
+      "+vpi",
+      "+vcs+lic+wait",
+      "+vcs+initreg+random",
+      "+define+CLOCK_PERIOD=1",
+      "-P",
+      "vpi.tab",
+      "-cpp",
+      "g++",
+      "-O2",
+      "-LDFLAGS",
+      "-lstdc++",
+      "-CFLAGS",
+      "\"%s\"".format(ccFlags mkString " ")
+    ) ++
+      moreVcsFlags
+
+    (vcsFlags, ccFlags)
+  }
+
+  def constructCSimulatorCommand(
+    topModule: String,
+    dir: java.io.File,
+    harness: java.io.File,
+    iFlags: Seq[String] = Seq.empty[String],
+    iCFlags: Seq[String] = Seq.empty[String]
+  ): String = {
+
+    val (cFlags, cCFlags) = composeFlags(
+      topModule,
+      dir,
+      iFlags ++ blackBoxVerilogList(dir) ++ Seq(
+        "-o",
+        topModule,
+        s"$topModule.v",
+        harness.toString,
+        "vpi.cpp"
+      ),
+      iCFlags
+    )
+
+    composeCommand(topModule, dir, cFlags, cCFlags)
+  }
+
+  def apply(topModule: String,
+            dir: java.io.File,
+            vcsHarness: java.io.File,
+            moreVcsFlags: Seq[String] = Seq.empty[String],
+            moreVcsCFlags: Seq[String] = Seq.empty[String],
+            editCommands: String = ""): ProcessBuilder = {
+
+    val finalCommand = editCSimulatorCommand(
+      constructCSimulatorCommand(
+        topModule,
+        dir,
+        vcsHarness,
+        moreVcsFlags,
+        moreVcsCFlags
+      ),
+      editCommands
+    )
+    println(s"$finalCommand")
+
+    Seq("bash", "-c", finalCommand)
+  }
+}

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -4,7 +4,7 @@ import java.io.{File, FileWriter}
 
 import chiseltest.backends.BackendExecutive
 import chiseltest.internal.{BackendInstance, WriteVcdAnnotation}
-import chisel3.{assert, MultiIOModule}
+import chisel3.{MultiIOModule, assert}
 import chisel3.experimental.DataMirror
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import firrtl.annotations.ReferenceTarget

--- a/src/test/scala/chiseltest/experimental/tests/VcsBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VcsBasicTests.scala
@@ -1,0 +1,32 @@
+package chisel3.experimental.tests
+
+import chisel3._
+import chiseltest._
+import chiseltest.experimental.TestOptionBuilder._
+import chiseltest.internal.VcsBackendAnnotation
+import org.scalatest._
+
+class VcsBasicTests extends FlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2 with Vcs"
+
+  val annos = Seq(VcsBackendAnnotation)
+
+  it should "build and simulate a basic test with input and output" in {
+    assume(firrtl.FileUtils.isVCSAvailable)
+
+    test(new Module {
+      val io = IO(new Bundle {
+        val in = Input(UInt(8.W))
+        val out = Output(UInt(8.W))
+      })
+      io.out := RegNext(io.in, 0.U)
+    }).withAnnotations(annos) { c =>
+      c.io.in.poke(0.U)
+      c.clock.step()
+      c.io.out.expect(0.U)
+      c.io.in.poke(42.U)
+      c.clock.step()
+      c.io.out.expect(42.U)
+    }
+  }
+}

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
@@ -8,7 +8,7 @@ import chiseltest.internal.VerilatorBackendAnnotation
 import org.scalatest._
 
 class VerilatorBasicTests extends FlatSpec with ChiselScalatestTester with Matchers {
-  behavior of "Testers2"
+  behavior of "Testers2 with Verilator"
 
   val annos = Seq(VerilatorBackendAnnotation)
 


### PR DESCRIPTION
- Create new VcsBackendAnnotation
- Create support utilities for Vcs building tools
  - CopyVpiFiles move vpi and header files into place
  - GenVcsVerilogHarness  Compile stuff
  - VcsAnnotations control behavior of the Vcs backend
- Create VcsBackend, a trivial sub-classing of VerilatorBackend
- Create VcsExecutive
  - constructs VcsBackEnd requirements calls the constructor
- Create SimpleVcsTests
- Added String to Uniquify Verilator and Vcs Tests
- Suppress VCS tests if VCS not present in path
  - Updates to PR #58
  - Fixed CopyVpiFiles
    - looks like this might fail if early file was there but a late one wasn't
    - this code came from chisel-testers
  - Fix top level test names
    - behavior of "Testers2 with Vcs"
    - behavior of "Testers2 with Verilator"
  - Shortened VCS to just see if a simple circuit will build and simulate.
    - in long run we still need mechanism to run an arbitrary test with arbitrary backend
- Create new VcsBackendAnnotation
- Create support utilities for Vcs building tools
  - CopyVpiFiles move vpi and header files into place
  - GenVcsVerilogHarness  Compile stuff
  - VcsAnnotations control behavior of the Vcs backend
- Create VcsBackend, a trivial sub-classing of VerilatorBackend
- Create VcsExecutive
  - constructs VcsBackEnd requirements calls the constructor
- Create SimpleVcsTests
- Added String to Uniquify Verilator and Vcs Tests
- Fixed CopyVpiFiles
  - looks like this might fail if early file was there but a late one wasn't
  - this code came from chisel-testers
- Fix top level test names
  - behavior of "Testers2 with Vcs"
  - behavior of "Testers2 with Verilator"
- Shortened VCS to just see if a simple circuit will build and simulate.
  - in long run we still need mechanism to run an arbitrary test with arbitrary backend