### PR TITLE
Fix non-input-poking error message

### DIFF
--- a/src/main/scala/chiseltest/experimental/UncheckedClockPoke.scala
+++ b/src/main/scala/chiseltest/experimental/UncheckedClockPoke.scala
@@ -15,14 +15,14 @@ package object UncheckedClockPoke {
   implicit class UncheckedPokeableClock(signal: Clock) {
     def high(): Unit = {
       if (DataMirror.directionOf(signal) != Direction.Input) {
-        throw new UnpokeableException("Cannot only poke inputs")
+        throw new UnpokeableException("Can only poke inputs")
       }
       Context().backend.pokeClock(signal, true)
     }
 
     def low(): Unit = {
       if (DataMirror.directionOf(signal) != Direction.Input) {
-        throw new UnpokeableException("Cannot only poke inputs")
+        throw new UnpokeableException("Can only poke inputs")
       }
       Context().backend.pokeClock(signal, false)
     }

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -60,7 +60,7 @@ package object chiseltest {
   implicit class testableData[T <: Data](x: T) {
     protected def pokeBits(signal: Data, value: BigInt): Unit = {
       if (DataMirror.directionOf(signal) != Direction.Input) {
-        throw new UnpokeableException("Cannot only poke inputs")
+        throw new UnpokeableException("Can only poke inputs")
       }
       // Some backends can behave incorrectly if too many bits are poked into their inputs
       val maskedValue = value & ((BigInt(1) << signal.widthOption.get) - 1)


### PR DESCRIPTION
The double negative actually inverts the error message =(