### PR TITLE
DecoupledDriver: support user to specify the error message format

### DIFF
--- a/src/main/scala/chiseltest/DecoupledDriver.scala
+++ b/src/main/scala/chiseltest/DecoupledDriver.scala
@@ -74,35 +74,35 @@ class DecoupledDriver[T <: Data](x: ReadyValidIO[T]) {
     }
   }
 
-  def expectDequeue(data: T): Unit = timescope {
+  def expectDequeue(data: T, msgGen: T => Option[String] = _ => None): Unit = timescope {
     // TODO: check for init
     x.ready.poke(true.B)
     fork.withRegion(Monitor) {
       waitForValid()
       x.valid.expect(true.B)
-      x.bits.expect(data)
+      x.bits.expect(data, msgGen)
     }.joinAndStep(getSinkClock)
   }
 
-  def expectDequeueNow(data: T): Unit = timescope {
+  def expectDequeueNow(data: T, msgGen: T => Option[String] = _ => None): Unit = timescope {
     // TODO: check for init
     x.ready.poke(true.B)
     fork.withRegion(Monitor) {
       x.valid.expect(true.B)
-      x.bits.expect(data)
+      x.bits.expect(data, msgGen)
     }.joinAndStep(getSinkClock)
   }
 
-  def expectDequeueSeq(data: Seq[T]): Unit = timescope {
+  def expectDequeueSeq(data: Seq[T], msgGen: T => Option[String] = _ => None): Unit = timescope {
     for (elt <- data) {
-      expectDequeue(elt)
+      expectDequeue(elt, msgGen)
     }
   }
 
-  def expectPeek(data: T): Unit = {
+  def expectPeek(data: T, msgGen: T => Option[String] = _ => None): Unit = {
     fork.withRegion(Monitor) {
       x.valid.expect(true.B)
-      x.bits.expect(data)
+      x.bits.expect(data, msgGen)
     }
   }
 

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -155,6 +155,12 @@ package object chiseltest {
 
     def expect(value: T): Unit = expectWithStale(value, None, false)
     def expect(value: T, message: String): Unit = expectWithStale(value, Some(message), false)
+    def expect(value: T, msgGen: T => Option[String] = _ => None): Unit = {
+      val errMsg =
+        if(msgGen(value).isEmpty) None
+        else Some(s"\nExpected:${msgGen(value).get}\nActual:${msgGen(peek()).get}\n")
+      expectWithStale(value, errMsg, false)
+    }
 
     /** @return the single clock that drives the source of this signal.
       * @throws ClockResolutionException if sources of this signal have more than one, or zero clocks

--- a/src/test/scala/chiseltest/tests/QueueTest.scala
+++ b/src/test/scala/chiseltest/tests/QueueTest.scala
@@ -60,6 +60,24 @@ class QueueTest extends FlatSpec with ChiselScalatestTester {
     }
   }
 
+
+  it should "pass through elements, using enqueueSeq and dequeueSeq, with custom error message" in {
+    test(new QueueModule(UInt(8.W), 2)) { c =>
+      c.in.initSource().setSourceClock(c.clock)
+      c.out.initSink().setSinkClock(c.clock)
+
+      val seq = Seq(42.U, 43.U, 44.U)
+
+
+      fork {
+        c.in.enqueueSeq(seq)
+      }.fork {
+        // print error value and expected value in hex
+        c.out.expectDequeueSeq(seq, x => Some(x.litValue().toString(16)))
+      }.join()
+    }
+  }
+
   it should "work with IrrevocableIO" in{
     test(new Module{
       val io = IO(new Bundle{


### PR DESCRIPTION
It's very useful to allow the user to specify the error message format such as print the expected value and the error value in hexadecimal (by default the value was printed in decimal).

For example, if I want to print the error value in hexadecimal, I can use a msgGen function which maps a value `x` to its hexadecimal string:

`x => Some(x.litValue().toString(16))`

Use the following test case:

```
 it should "pass through elements, using enqueueSeq and dequeueSeq, with custom error message" in {
    test(new QueueModule(UInt(8.W), 2)) { c =>
      c.in.initSource().setSourceClock(c.clock)
      c.out.initSink().setSinkClock(c.clock)

      val seq = Seq(42.U, 43.U, 44.U)
      val errSeq = seq map (x => (x.litValue() + 1).U)

      fork {
        c.in.enqueueSeq(seq)
      }.fork {
        // print error value and expected value in hex
        c.out.expectDequeueSeq(errSeq, x => Some(x.litValue().toString(16)))
      }.join()
    }
  }
```
The error message would be:
```
out_bits=42 did not equal expected=43: Some(
Expected:2b
Actual:2a
) (lines in QueueTest.scala: 76, 65, 76)
ScalaTestFailureLocation: chiseltest.DecoupledDriver at (DecoupledDriver.scala:83)
```