### PR TITLE
Display hex and type-specific values on expect failures

### DIFF
--- a/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
@@ -79,11 +79,12 @@ extends BackendInstance[T] with ThreadedBackend[T] {
     a
   }
 
-  override def expectBits(signal: Data, value: BigInt, message: Option[String], stale: Boolean): Unit = {
+  override def expectBits(signal: Data, value: BigInt, message: Option[String], decode: Option[BigInt => String],
+                          stale: Boolean): Unit = {
     require(!stale, "Stale peek not yet implemented")
 
     debugLog(s"${resolveName(signal)} ?> $value")
-    Context().env.testerExpect(value, peekBits(signal, stale), resolveName(signal), message)
+    Context().env.testerExpect(value, peekBits(signal, stale), resolveName(signal), message, decode)
   }
 
   protected val clockCounter : mutable.HashMap[Clock, Int] = mutable.HashMap()

--- a/src/main/scala/chiseltest/internal/BackendInterface.scala
+++ b/src/main/scala/chiseltest/internal/BackendInterface.scala
@@ -49,7 +49,8 @@ trait BackendInterface {
     */
   def peekBits(signal: Data, stale: Boolean): BigInt
 
-  def expectBits(signal: Data, value: BigInt, message: Option[String], stale: Boolean): Unit
+  def expectBits(signal: Data, value: BigInt, message: Option[String], decode: Option[BigInt => String],
+                 stale: Boolean): Unit
 
   /**
    * Sets the timeout of the clock: the number of cycles the clock can advance without

--- a/src/main/scala/chiseltest/internal/TestEnvInterface.scala
+++ b/src/main/scala/chiseltest/internal/TestEnvInterface.scala
@@ -56,6 +56,14 @@ trait TestEnvInterface {
     }
   }
 
+  protected def bigintToHex(x: BigInt): String = {
+    if (x < 0) {
+      f"-0x${-x}%x"
+    } else {
+      f"0x$x%x"
+    }
+  }
+
   /** Expect a specific value on a wire, calling testerFail if the expectation isn't met.
     * Failures queued until the next checkpoint.
     */
@@ -78,9 +86,11 @@ trait TestEnvInterface {
 
       val (actualStr, expectedStr) = decode match {
         case Some(decode) =>
-          (f"${decode(actual)} ($actual, 0x$actual%x)", s"${decode(expected)} ($expected, 0x$actual%x)")
+          (s"${decode(actual)} ($actual, ${bigintToHex(actual)})",
+              s"${decode(expected)} ($expected, ${bigintToHex(expected)})")
         case None =>
-          (f"$actual (0x$actual%x)", s"$expected (0x$actual%x)")
+          (s"$actual (${bigintToHex(actual)})",
+              s"$expected (${bigintToHex(expected)})")
       }
 
       val message = s"$signal=$actualStr did not equal expected=$expectedStr$appendMsg$detailedTrace"

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
@@ -114,6 +114,7 @@ class VerilatorBackend[T <: MultiIOModule](
   override def expectBits(signal: Data,
                           value: BigInt,
                           message: Option[String],
+                          decode: Option[BigInt => String],
                           stale: Boolean): Unit = {
     require(!stale, "Stale peek not yet implemented")
 
@@ -122,7 +123,8 @@ class VerilatorBackend[T <: MultiIOModule](
       value,
       peekBits(signal, stale),
       resolveName(signal),
-      message
+      message,
+      decode
     )
   }
 

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -7,7 +7,6 @@ import chisel3.experimental.{DataMirror, Direction, FixedPoint, Interval, EnumTy
 import chisel3.experimental.BundleLiterals._
 import chisel3.util._
 
-
 /** Basic interfaces and implicit conversions for testers2
   */
 package object chiseltest {

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -61,10 +61,17 @@ package object chiseltest {
   private object BitsDecoders {
     import chisel3.internal.firrtl.{BinaryPoint, KnownBinaryPoint, UnknownBinaryPoint}
 
-    def boolBitsToString(bits: BigInt): String = "[unimplemented bool conversion]"
+    def boolBitsToString(bits: BigInt): String = (bits != 0).toString
 
     def fixedToString(binaryPoint: BinaryPoint): BigInt => String = {
-      def inner(bits: BigInt): String = "[unimplemented fixed conversion]"
+      def inner(bits: BigInt): String = {
+        binaryPoint match {
+          case KnownBinaryPoint(binaryPoint) =>
+            val bpInteger = 1 << binaryPoint
+            (bits.toFloat / bpInteger).toString
+          case UnknownBinaryPoint => "[unknown binary point]"
+        }
+      }
       inner
     }
 

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -76,7 +76,7 @@ package object chiseltest {
     }
 
     def enumToString(record: EnumType): BigInt => String = {
-      def inner(bits: BigInt): String = "[unimplemented record conversion]"
+      def inner(bits: BigInt): String = "[unimplemented enum decode]"
       inner
     }
   }

--- a/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
@@ -1,0 +1,59 @@
+package chiseltest.tests
+
+import chisel3._
+import chiseltest._
+import org.scalatest._
+
+class FaultDecoderTest extends FlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2"
+
+  it should "display both decimal and hex for ints" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule(42.U)) { c =>
+        c.out.expect(0.U)
+      }
+    }
+    exc.getMessage should include ("42 (0x2a)")
+    exc.getMessage should include ("expected=0 (0x0)")
+  }
+
+  it should "display both decimal and hex for signed ints" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule(-42.S)) { c =>
+        c.out.expect(-2.S)
+      }
+    }
+    exc.getMessage should include ("-42 (-0x2a)")
+    exc.getMessage should include ("expected=-2 (-0x2)")
+  }
+
+  it should "display boolean for bools" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule(true.B)) { c =>
+        c.out.expect(false.B)
+      }
+    }
+    exc.getMessage should include ("true (1, 0x1)")
+    exc.getMessage should include ("expected=false (0, 0x0)")
+  }
+
+  it should "display decimal for fixedpoint" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule((1.5).F(4.W, 1.BP))) { c =>
+        c.out.expect((1).F(4.W, 1.BP))
+      }
+    }
+    exc.getMessage should include ("1.5 (3, 0x3)")
+    exc.getMessage should include ("expected=1.0 (2, 0x2)")
+  }
+
+  it should "display decimal for negative fixedpoint" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule((-2.0).F(4.W, 1.BP))) { c =>
+        c.out.expect((-0.5).F(4.W, 1.BP))
+      }
+    }
+    exc.getMessage should include ("-2.0 (-4, -0x4)")
+    exc.getMessage should include ("expected=-0.5 (-1, -0x1)")
+  }
+}

--- a/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
@@ -39,8 +39,8 @@ class FaultDecoderTest extends FlatSpec with ChiselScalatestTester with Matchers
 
   it should "display decimal for fixedpoint" in {
     val exc = intercept[exceptions.TestFailedException] {
-      test(new StaticModule((1.5).F(4.W, 1.BP))) { c =>
-        c.out.expect((1).F(4.W, 1.BP))
+      test(new StaticModule((1.5).F(1.BP))) { c =>
+        c.out.expect((1).F(1.BP))
       }
     }
     exc.getMessage should include ("1.5 (3, 0x3)")
@@ -49,11 +49,36 @@ class FaultDecoderTest extends FlatSpec with ChiselScalatestTester with Matchers
 
   it should "display decimal for negative fixedpoint" in {
     val exc = intercept[exceptions.TestFailedException] {
-      test(new StaticModule((-2.0).F(4.W, 1.BP))) { c =>
-        c.out.expect((-0.5).F(4.W, 1.BP))
+      test(new StaticModule((-2.0).F(1.BP))) { c =>
+        c.out.expect((-0.5).F(1.BP))
       }
     }
     exc.getMessage should include ("-2.0 (-4, -0x4)")
     exc.getMessage should include ("expected=-0.5 (-1, -0x1)")
+  }
+
+  it should "display decimal for intervals" in {
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule((1.5).I(1.BP))) { c =>
+        c.out.expect((1.0).I(1.BP))
+      }
+    }
+    exc.getMessage should include ("1.5 (3, 0x3)")
+    exc.getMessage should include ("expected=1.0 (2, 0x2)")
+  }
+
+  ignore should "display names for enums" in {  // needs better reflection support in enums
+    import chisel3.experimental.ChiselEnum
+    object EnumExample extends ChiselEnum {
+      val e0, e1, e2 = Value
+    }
+
+    val exc = intercept[exceptions.TestFailedException] {
+      test(new StaticModule(EnumExample.e0)) { c =>
+        c.out.expect(EnumExample.e1)
+      }
+    }
+    exc.getMessage should include ("e0 (0, 0x0)")
+    exc.getMessage should include ("expected=e1 (1, 0x1)")
   }
 }


### PR DESCRIPTION
For expect failures, the error now includes the hex value, decimal value, and a type-specific decoding (where applicable).
For example:
- UInt case: `out=42 (0x2a) did not equal expected=0 (0x0)`
- Bool case: `out=true (1, 0x1) did not equal expected=false (0, 0x0)`
- Fixed case: `out=-2.0 (-4, -0x4) did not equal expected=-0.5 (-1, -0x1)`
- Enum case: `out=[unimplemented enum decode] (0, 0x0) did not equal expected=[unimplemented enum decode] (1, 0x1)` (@hngenc, I think StrongEnum needs some kind of reflection API to get the name from a integer? - related: #111)

Architecturally, this passes a decode function through the internals of `wire.expect` -> `BackendInterface.expectBits` -> `TestEnvInterface.testerExpect`. Does not expose any additional APIs. Bundles aren't affected, since the specific sub-field should fail.

Addresses the underlying issue from #168 with infrastructural support.