### PR TITLE
remove all usage of deprecated firrtl APIs

### DIFF
--- a/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
@@ -8,10 +8,10 @@ import chisel3.experimental.DataMirror
 import chisel3.MultiIOModule
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import firrtl.annotations.ReferenceTarget
-import firrtl.stage.CompilerAnnotation
+import firrtl.stage.RunFirrtlTransformAnnotation
 import firrtl.transforms.{CheckCombLoops, CombinationalPath}
 import treadle.stage.TreadleTesterPhase
-import treadle.{TreadleCircuitStateAnnotation, TreadleFirrtlFormHint, TreadleTesterAnnotation}
+import treadle.{TreadleCircuitStateAnnotation, TreadleTesterAnnotation}
 
 object TreadleExecutive extends BackendExecutive {
   import firrtl._
@@ -41,10 +41,11 @@ object TreadleExecutive extends BackendExecutive {
     }.toMap
 
     // This generates the firrtl circuit needed by the TreadleTesterPhase
-    annotationSeq = (new ChiselStage).run(annotationSeq ++ Seq(CompilerAnnotation(new LowFirrtlCompiler)))
+    val runLowFirrtl = RunFirrtlTransformAnnotation(new LowFirrtlEmitter)
+    annotationSeq = (new ChiselStage).run(annotationSeq ++ Seq(runLowFirrtl))
 
     // This generates a TreadleTesterAnnotation with a treadle tester instance
-    annotationSeq = (new TreadleTesterPhase).transform(annotationSeq :+ TreadleFirrtlFormHint(LowForm))
+    annotationSeq = (new TreadleTesterPhase).transform(annotationSeq)
 
     val treadleTester = annotationSeq.collectFirst { case TreadleTesterAnnotation(t) => t }.getOrElse(
       throw new Exception(

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
@@ -8,7 +8,7 @@ import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import chiseltest.internal.BackendInstance
 import chiseltest.backends.BackendExecutive
 import firrtl.annotations.{DeletedAnnotation, ReferenceTarget}
-import firrtl.stage.CompilerAnnotation
+import firrtl.stage.RunFirrtlTransformAnnotation
 import firrtl.transforms.CombinationalPath
 
 object VcsExecutive extends BackendExecutive {
@@ -59,11 +59,12 @@ object VcsExecutive extends BackendExecutive {
     //
     // This run also creates the target dir and places the verilog in it
 
+    val runVerilogEmitter = RunFirrtlTransformAnnotation(new VerilogEmitter)
     val compiledAnnotations = (new ChiselStage)
       .run(
         annotationSeq ++ Seq(
           generatorAnnotation,
-          CompilerAnnotation(new VerilogCompiler())
+          runVerilogEmitter
         )
       )
       .filterNot(_.isInstanceOf[DeletedAnnotation])

--- a/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
@@ -98,7 +98,7 @@ trait EditableBuildCSimulatorCommand {
     * @return sequence of strings (suitable for passing as arguments to the simulator builder) specifying a flag and the absolute path to the file.
     */
   def blackBoxVerilogList(dir: java.io.File): Seq[String] = {
-    val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.fileListName)
+    val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.defaultFileListName)
     if(list_file.exists()) {
       Seq("-f", list_file.getAbsolutePath)
     } else {

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -8,8 +8,9 @@ import chisel3.{MultiIOModule, assert}
 import chisel3.experimental.DataMirror
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import firrtl.annotations.ReferenceTarget
-import firrtl.stage.CompilerAnnotation
+import firrtl.stage.RunFirrtlTransformAnnotation
 import firrtl.transforms.CombinationalPath
+import firrtl.util.BackendCompilationUtilities
 
 object VerilatorExecutive extends BackendExecutive {
   import firrtl._
@@ -57,9 +58,8 @@ object VerilatorExecutive extends BackendExecutive {
     // - CommandEditsFile
     // - TestCommandOverride
     // - CombinationalPath
-    val compiledAnnotations = (new ChiselStage).run(
-      elaboratedAnno :+ CompilerAnnotation(new VerilogCompiler())
-    )
+    val runVerilogEmitter = RunFirrtlTransformAnnotation(new VerilogEmitter)
+    val compiledAnnotations = (new ChiselStage).run(elaboratedAnno :+ runVerilogEmitter)
 
     val cppHarnessFileName = s"${circuit.name}-harness.cpp"
     val cppHarnessFile = new File(targetDir, cppHarnessFileName)
@@ -94,7 +94,7 @@ object VerilatorExecutive extends BackendExecutive {
       s"verilator command failed on circuit ${circuit.name} in work dir $targetDir"
     )
     assert(
-      chisel3.Driver.cppToExe(circuit.name, targetDirFile).! == 0,
+      BackendCompilationUtilities.cppToExe(circuit.name, targetDirFile).! == 0,
       s"Compilation of verilator generated code failed for circuit ${circuit.name} in work dir $targetDir"
     )
 


### PR DESCRIPTION
This is supposed to be a minimal patch to remove the reliance on deprecated firrtl APIs.
Among other things, the `CompilerAnnotation` might be removed in the next firrtl release.

Can someone please check the VCS backend to see if I broke anything?