### PR TITLE
Scalatest 3.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,8 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.0",
+  "org.scalatest" %% "scalatest" % "3.0.8",
+  "org.scalatest" %% "scalatest" % "3.2.0" % "test",
   "com.lihaoyi" %% "utest" % "latest.integration"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.8",
+  "org.scalatest" %% "scalatest" % "3.2.0",
   "com.lihaoyi" %% "utest" % "latest.integration"
 )
 

--- a/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
@@ -20,7 +20,7 @@ import chisel3._
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.internal.VerilatorBackendAnnotation
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 class HasOddWidthSInt extends MultiIOModule {
   val in = IO(Input(SInt(15.W)))
@@ -34,7 +34,7 @@ class HasOddWidthSInt extends MultiIOModule {
 // The poke of a negative number into an SInt, FixedPoint, or Interval input that is not a standard word size
 // would break in verilator if the poked value was not masked to the correct number of
 // bits first. This was fixed by masking those values to the proper width before poking
-class NegativeInputValuesTest extends FreeSpec with ChiselScalatestTester {
+class NegativeInputValuesTest extends AnyFreeSpec with ChiselScalatestTester {
   "Negative input values on odd width SInt should not cause verilator to fail" in {
     test(new HasOddWidthSInt).withAnnotations(Seq(VerilatorBackendAnnotation)) { dut =>
       for(inputValue <- Seq(-4, -3, -2, -1, 0, 1, 2, 3, 4)) {

--- a/src/test/scala/chiseltest/experimental/tests/VcsBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VcsBasicTests.scala
@@ -5,8 +5,10 @@ import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.internal.VcsBackendAnnotation
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class VcsBasicTests extends FlatSpec with ChiselScalatestTester with Matchers {
+class VcsBasicTests extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2 with Vcs"
 
   val annos = Seq(VcsBackendAnnotation)

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
@@ -6,8 +6,10 @@ import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.internal.VerilatorBackendAnnotation
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class VerilatorBasicTests extends FlatSpec with ChiselScalatestTester with Matchers {
+class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2 with Verilator"
 
   val annos = Seq(VerilatorBackendAnnotation)

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorClockPokeTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorClockPokeTest.scala
@@ -9,8 +9,9 @@ import chisel3.util._
 import org.scalatest._
 import treadle.executable.ClockInfo
 import treadle.{ClockInfoAnnotation, WriteVcdAnnotation}
+import org.scalatest.flatspec.AnyFlatSpec
 
-class VerilatorClockPokeTest extends FlatSpec with ChiselScalatestTester {
+class VerilatorClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with a clock input"
 
   it should "verilator-clock-poke" in {

--- a/src/test/scala/chiseltest/tests/AsyncClockTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncClockTest.scala
@@ -3,8 +3,9 @@ package chiseltest.tests
 import chisel3._
 import chiseltest._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class AsyncClockTest extends FlatSpec with ChiselScalatestTester {
+class AsyncClockTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with clock crossing signals"
 
   it should "work with async clock signals" in {

--- a/src/test/scala/chiseltest/tests/AsyncResetTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncResetTest.scala
@@ -8,6 +8,7 @@ import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.internal.VerilatorBackendAnnotation
 import firrtl.AnnotationSeq
 import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
 
 /**
   * circuit that illustrates usage of async register
@@ -41,7 +42,7 @@ class AsyncResetFeedbackModule() extends MultiIOModule {
   }
 }
 
-class AsyncResetTest extends FreeSpec with ChiselScalatestTester {
+class AsyncResetTest extends AnyFreeSpec with ChiselScalatestTester {
 
   val annotations: AnnotationSeq = {
     if(true) Seq() else Seq(VerilatorBackendAnnotation)

--- a/src/test/scala/chiseltest/tests/AsyncResetUsingBlackBoxTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncResetUsingBlackBoxTest.scala
@@ -8,6 +8,7 @@ import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.experimental.{AsyncResetBlackBoxFactory, AsyncResetReg}
 import org.scalatest._
 import treadle.BlackBoxFactoriesAnnotation
+import org.scalatest.freespec.AnyFreeSpec
 
 /**
   * circuit that illustrates usage of async register
@@ -53,7 +54,7 @@ class AsyncResetUsingBlackBoxFeedbackModule() extends Module {
   reg1.en := 1.U
 }
 
-class AsyncResetUsingBlackBoxTest extends FreeSpec with ChiselScalatestTester {
+class AsyncResetUsingBlackBoxTest extends AnyFreeSpec with ChiselScalatestTester {
   private val annotations = Seq(BlackBoxFactoriesAnnotation(Seq(new AsyncResetBlackBoxFactory)))
 
   "register is zero, after tester startup's default reset" in {

--- a/src/test/scala/chiseltest/tests/BasicTest.scala
+++ b/src/test/scala/chiseltest/tests/BasicTest.scala
@@ -5,8 +5,10 @@ import org.scalatest._
 import chisel3._
 import chisel3.experimental.BundleLiterals._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BasicTest extends FlatSpec with ChiselScalatestTester with Matchers {
+class BasicTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   it should "test static circuits" in {

--- a/src/test/scala/chiseltest/tests/BoreTest.scala
+++ b/src/test/scala/chiseltest/tests/BoreTest.scala
@@ -5,8 +5,10 @@ package chiseltest.tests
 import chisel3._
 import chiseltest._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BoreTest extends FlatSpec with ChiselScalatestTester with Matchers {
+class BoreTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   class Constant extends MultiIOModule {

--- a/src/test/scala/chiseltest/tests/BundleLiteralsSpec.scala
+++ b/src/test/scala/chiseltest/tests/BundleLiteralsSpec.scala
@@ -5,8 +5,10 @@ import org.scalatest._
 import chisel3._
 import chiseltest._
 import chisel3.experimental.BundleLiterals._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BundleLiteralsSpec extends FlatSpec with ChiselScalatestTester with Matchers {
+class BundleLiteralsSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   class DoubleElements extends Bundle {

--- a/src/test/scala/chiseltest/tests/ChiselEnumTest.scala
+++ b/src/test/scala/chiseltest/tests/ChiselEnumTest.scala
@@ -5,8 +5,10 @@ import org.scalatest._
 import chisel3._
 import chiseltest._
 import chisel3.experimental.ChiselEnum
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ChiselEnumTest extends FlatSpec with ChiselScalatestTester with Matchers {
+class ChiselEnumTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   object EnumExample extends ChiselEnum {

--- a/src/test/scala/chiseltest/tests/ClockCrossingTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockCrossingTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ClockCrossingTest extends FlatSpec with ChiselScalatestTester {
+class ClockCrossingTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with clock crossing signals"
 
   it should "test crossing from a 2:1 divider domain" in {

--- a/src/test/scala/chiseltest/tests/ClockDividerTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockDividerTest.scala
@@ -5,8 +5,9 @@ import org.scalatest._
 import chisel3._
 import chisel3.util._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ClockDividerTest extends FlatSpec with ChiselScalatestTester {
+class ClockDividerTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with a clock divider"
 
   it should "test 1:2 clock divider counter" in {

--- a/src/test/scala/chiseltest/tests/ClockPeekTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockPeekTest.scala
@@ -6,8 +6,9 @@ import chisel3._
 import chiseltest._
 import chiseltest.experimental.UncheckedClockPoke._
 import chiseltest.experimental.UncheckedClockPeek._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ClockPeekTest extends FlatSpec with ChiselScalatestTester {
+class ClockPeekTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with clock peeking"
 
   it should "work as expected" in {

--- a/src/test/scala/chiseltest/tests/ClockPokeTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockPokeTest.scala
@@ -6,8 +6,9 @@ import chisel3._
 import chisel3.util._
 import chiseltest._
 import chiseltest.experimental.UncheckedClockPoke._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ClockPokeTest extends FlatSpec with ChiselScalatestTester {
+class ClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with a clock input"
 
   it should "work as expected" in {

--- a/src/test/scala/chiseltest/tests/CombinationalPathTest.scala
+++ b/src/test/scala/chiseltest/tests/CombinationalPathTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CombinationalPathTest extends FlatSpec with ChiselScalatestTester {
+class CombinationalPathTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2"
 
   it should "detect combinationally-dependent operations when a poke is active" in {

--- a/src/test/scala/chiseltest/tests/ElementTest.scala
+++ b/src/test/scala/chiseltest/tests/ElementTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 import chisel3._
 import chisel3.experimental._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ElementTest extends FlatSpec with ChiselScalatestTester {
+class ElementTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with Element types"
 
   // TODO: automatically detect overflow conditions and error out

--- a/src/test/scala/chiseltest/tests/ExceptionPropagationTest.scala
+++ b/src/test/scala/chiseltest/tests/ExceptionPropagationTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ExceptionPropagationTest extends FlatSpec with ChiselScalatestTester {
+class ExceptionPropagationTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2"
 
   class PropagationTestException extends Exception

--- a/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
@@ -3,8 +3,10 @@ package chiseltest.tests
 import chisel3._
 import chiseltest._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FaultDecoderTest extends FlatSpec with ChiselScalatestTester with Matchers {
+class FaultDecoderTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   it should "display both decimal and hex for ints" in {

--- a/src/test/scala/chiseltest/tests/FaultLocatorTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultLocatorTest.scala
@@ -15,7 +15,7 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
       test(new StaticModule(42.U)) { c =>
         c.out.expect(0.U)
       }
-    }.failedCodeFileNameAndLineNumberString.get should equal ("FaultLocatorTest.scala:14")
+    }.failedCodeFileNameAndLineNumberString.get should equal ("FaultLocatorTest.scala:16")
   }
 
   it should "locate source lines across threads" in {
@@ -27,7 +27,7 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
         }.join()
       }
     }
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*22.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*24.*\)""")
   }
 
   it should "locate source lines in libraries" in {
@@ -43,7 +43,7 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
     }
     // Only check the filename to avoid this being too brittle as implementation changes
     exc.failedCodeFileNameAndLineNumberString.get should startWith ("DecoupledDriver.scala:")
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*39.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*41.*\)""")
   }
 
   it should "locate source lines, even in a different thread" in {
@@ -60,6 +60,6 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
       }
     }
     exc.failedCodeFileNameAndLineNumberString.get should startWith ("DecoupledDriver.scala:")
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*56.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*58.*\)""")
   }
 }

--- a/src/test/scala/chiseltest/tests/FaultLocatorTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultLocatorTest.scala
@@ -4,8 +4,10 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FaultLocatorTest extends FlatSpec with ChiselScalatestTester with Matchers {
+class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   it should "locate source lines" in {

--- a/src/test/scala/chiseltest/tests/NoScalatestTesterTest.scala
+++ b/src/test/scala/chiseltest/tests/NoScalatestTesterTest.scala
@@ -5,9 +5,10 @@ package chiseltest.tests
 import chisel3._
 import chiseltest._
 import chiseltest.RawTester.test
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class NoScalatestTesterTest extends FreeSpec with Matchers {
+class NoScalatestTesterTest extends AnyFreeSpec with Matchers {
   "This tester does not rely on scalatest to run" in {
     def shiftTest(in: UInt, out: UInt, clk: Clock, value: UInt) {
       timescope {

--- a/src/test/scala/chiseltest/tests/OptionsBackwardCompatibilityTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsBackwardCompatibilityTest.scala
@@ -9,13 +9,14 @@ import chiseltest.experimental.TestOptionBuilder._
 import firrtl.{AnnotationSeq, ExecutionOptionsManager}
 import org.scalatest._
 import treadle.{BlackBoxFactoriesAnnotation, HasTreadleSuite}
+import org.scalatest.freespec.AnyFreeSpec
 
 /** This test uses a deprecated class and method to test backward compatibility
   *
   * @note This test is used to illustrate workaround for treadle
   *
   */
-class OptionsBackwardCompatibilityTest extends FreeSpec with ChiselScalatestTester {
+class OptionsBackwardCompatibilityTest extends AnyFreeSpec with ChiselScalatestTester {
   private val manager = new ExecutionOptionsManager("asyncResetRegTest") with HasTreadleSuite {
     treadleOptions = treadleOptions.copy(
       blackBoxFactories = Seq(new AsyncResetBlackBoxFactory)

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -11,8 +11,10 @@ import firrtl.options.OutputAnnotationFileAnnotation
 import firrtl.stage.OutputFileAnnotation
 import org.scalatest._
 import treadle.{VerboseAnnotation, WriteVcdAnnotation}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class OptionsPassingTest extends FlatSpec with ChiselScalatestTester with Matchers {
+class OptionsPassingTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   it should "write vcd output when passing in a WriteVcdAnnotation" in {

--- a/src/test/scala/chiseltest/tests/QueueTest.scala
+++ b/src/test/scala/chiseltest/tests/QueueTest.scala
@@ -5,9 +5,10 @@ import org.scalatest._
 import chisel3._
 import chiseltest._
 import chisel3.util._
+import org.scalatest.flatspec.AnyFlatSpec
 
 
-class QueueTest extends FlatSpec with ChiselScalatestTester {
+class QueueTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with Queue"
 
   it should "pass through elements, using enqueueNow" in {

--- a/src/test/scala/chiseltest/tests/RegionsTest.scala
+++ b/src/test/scala/chiseltest/tests/RegionsTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class RegionsTest extends FlatSpec with ChiselScalatestTester {
+class RegionsTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 Regions"
 
   it should "resolve read-after-write dependencies" in {

--- a/src/test/scala/chiseltest/tests/ShiftRegisterTest.scala
+++ b/src/test/scala/chiseltest/tests/ShiftRegisterTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ShiftRegisterTest extends FlatSpec with ChiselScalatestTester {
+class ShiftRegisterTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2"
 
   it should "test shift registers with abstractions" in {

--- a/src/test/scala/chiseltest/tests/ThreadJoinTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadJoinTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ThreadJoinTest extends FlatSpec with ChiselScalatestTester {
+class ThreadJoinTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 threading fork-joins"
 
   class PassthroughModule[T <: Data](ioType: T) extends Module {

--- a/src/test/scala/chiseltest/tests/ThreadSafetyLocatorTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadSafetyLocatorTest.scala
@@ -22,7 +22,7 @@ class ThreadSafetyLocatorTest extends AnyFlatSpec with ChiselScalatestTester {
         }.join
       }
     }.getMessage()
-    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:15")
-    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:18")
+    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:20")
+    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:17")
   }
 }

--- a/src/test/scala/chiseltest/tests/ThreadSafetyLocatorTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadSafetyLocatorTest.scala
@@ -3,9 +3,11 @@ package chiseltest.tests
 import chisel3._
 import chiseltest._
 import org.scalatest._
-import org.scalatest.Matchers._
+import matchers.should.Matchers._
+import org.scalatest.matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ThreadSafetyLocatorTest extends FlatSpec with ChiselScalatestTester {
+class ThreadSafetyLocatorTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 thread safety checker"
 
   it should "locate source lines for simultaneous pokes from parallel threads" in {

--- a/src/test/scala/chiseltest/tests/ThreadSafetyTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadSafetyTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ThreadSafetyTest extends FlatSpec with ChiselScalatestTester {
+class ThreadSafetyTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 thread safety checker"
 
   it should "disallow simultaneous pokes from parallel threads" in {

--- a/src/test/scala/chiseltest/tests/TimeoutTest.scala
+++ b/src/test/scala/chiseltest/tests/TimeoutTest.scala
@@ -4,8 +4,10 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TimeoutTest extends FlatSpec with ChiselScalatestTester with Matchers {
+class TimeoutTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   it should "fail on default timeout at 1000 cycles" in {

--- a/src/test/scala/chiseltest/tests/TimescopeTest.scala
+++ b/src/test/scala/chiseltest/tests/TimescopeTest.scala
@@ -4,8 +4,9 @@ import org.scalatest._
 
 import chisel3._
 import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class TimescopeTest extends FlatSpec with ChiselScalatestTester {
+class TimescopeTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 timescopes"
 
   it should "revert signals at the end" in {

--- a/src/test/scala/chiseltest/tests/ValidQueueTest.scala
+++ b/src/test/scala/chiseltest/tests/ValidQueueTest.scala
@@ -7,6 +7,7 @@ import chiseltest.experimental.TestOptionBuilder._
 import chisel3.util.{Pipe, Valid}
 import org.scalatest._
 import treadle.VerboseAnnotation
+import org.scalatest.flatspec.AnyFlatSpec
 
 class ValidQueueModule(typeGen: Data, val delay: Int) extends MultiIOModule {
   val in = IO(Flipped(Valid(typeGen)))
@@ -16,7 +17,7 @@ class ValidQueueModule(typeGen: Data, val delay: Int) extends MultiIOModule {
 }
 
 
-class ValidQueueTest extends FlatSpec with ChiselScalatestTester {
+class ValidQueueTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with ValidQueue"
 
   it should "pass through elements, using enqueueNow" in {

--- a/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
+++ b/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
@@ -4,7 +4,7 @@ package chiseltest.tests
 
 import chisel3._
 import chiseltest._
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 class UsesVec extends MultiIOModule {
   val in   = IO(Input(Vec(4, UInt(5.W))))
@@ -14,7 +14,7 @@ class UsesVec extends MultiIOModule {
   out := in(addr)
 }
 
-class UsesVecSpec extends FreeSpec with ChiselScalatestTester {
+class UsesVecSpec extends AnyFreeSpec with ChiselScalatestTester {
   "run" in {
     test(new UsesVec) { c =>
       c.in(0).poke(5.U)


### PR DESCRIPTION
This PR updates scalatest to 3.2.0.

Most of the work was done automatically by scala-steward, although there were a few tests I had to fix manually.

The fixes were mostly to do with checking the output from exceptions raised by scalatest, which had changed slightly since 3.2.0.