### PR TITLE
Fix legacy support for ExecutionOptions

### DIFF
--- a/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
@@ -6,10 +6,10 @@ import chiseltest._
 import chiseltest.internal.{TreadleBackendAnnotation, VerilatorBackendAnnotation}
 import chisel3._
 import treadle.HasTreadleSuite
-import firrtl.stage.CompilerAnnotation
+import firrtl.stage.{CompilerAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.{
-  AnnotationSeq, ExecutionOptionsManager, LowFirrtlCompiler, MinimumVerilogCompiler,
-  NoneCompiler, SystemVerilogCompiler, VerilogCompiler}
+  AnnotationSeq, ExecutionOptionsManager, FirrtlEmitter, LowFirrtlCompiler, MinimumVerilogCompiler,
+  NoneCompiler, SystemVerilogCompiler, VerilogCompiler, VerilogEmitter}
 
 package object TestOptionBuilder {
   implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
@@ -29,6 +29,8 @@ package object TestOptionBuilder {
         case CompilerAnnotation(compiler) if compiler.isInstanceOf[VerilogCompiler]        => VerilatorBackendAnnotation
         case CompilerAnnotation(compiler) if compiler.isInstanceOf[MinimumVerilogCompiler] => VerilatorBackendAnnotation
         case CompilerAnnotation(compiler) if compiler.isInstanceOf[SystemVerilogCompiler]  => VerilatorBackendAnnotation
+        case RunFirrtlTransformAnnotation(_: FirrtlEmitter)                                => TreadleBackendAnnotation
+        case RunFirrtlTransformAnnotation(_: VerilogEmitter)                               => VerilatorBackendAnnotation
         case anno => anno
       }
 


### PR DESCRIPTION
CompilerAnnotation has been deprecated and is now rarely used in FIRRTL,
replaced with RunFirrtlTransformAnnotation of an Emitter. The
(deprecated) support for ExecutionOptions now handles this change.

https://github.com/freechipsproject/firrtl/pull/1870 necessitates this change. Concretely, `FirrtlExecutionOptions` no longer create `CompilerAnnotation`, instead they create `RunFirrtlTransformAnnotation` with an `Emitter`.