### PR TITLE
tests: Alu: add example of reusing the same test for different data

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See the test cases for examples:
     ```scala
     import chisel3.experimental.BundleLiterals._
     ```
+- [AlutTest](src/test/scala/chiseltest/tests/AluTest.scala) shows an example of re-using the same test for different data
 - [ShiftRegisterTest](src/test/scala/chiseltest/tests/ShiftRegisterTest.scala) shows an example of using fork/join to define a test helper function, where multiple invocations of it are pipelined using `fork`.
 - [VerilatorBasicTests](src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala) shows an example using Verilator as the simulator.
   - Note: the simulator is selected by passing an annotation into the `test` function, which requires experimental imports:

--- a/src/test/scala/chiseltest/tests/AluTest.scala
+++ b/src/test/scala/chiseltest/tests/AluTest.scala
@@ -1,0 +1,85 @@
+package chiseltest.tests
+
+import chisel3._
+import chiseltest._
+import chiseltest.ChiselScalatestTester
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Example of test that is "shared by multiple fixture objects
+  * More information on https://www.scalatest.org/user_guide/sharing_tests
+  */
+
+trait AluBehavior {
+  this: AnyFlatSpec with ChiselScalatestTester =>
+
+  def mask(s: Int): Int = (1 << s) - 1
+
+  def testAddition(a: Int, b: Int, s: Int): Unit = {
+    val result = (a + b) & mask(s)
+    it should s"+ $a, $b and the result == $result" in {
+      test(new Alu(s)) { c =>
+        c.io.fn.poke(0.U)
+        c.io.a.poke(a.U(s.W))
+        c.io.b.poke(b.U(s.W))
+        c.clock.step()
+        c.io.result.expect(result.U(s.W))
+      }
+    }
+  }
+
+  def testOr(a: Int, b: Int, s: Int): Unit = {
+    val result = (a | b) & mask(s)
+    it should s"| $a, $b and the result == $result" in {
+      test(new Alu(s)) { c =>
+        c.io.fn.poke(2.U)
+        c.io.a.poke(a.U(s.W))
+        c.io.b.poke(b.U(s.W))
+        c.clock.step()
+        c.io.result.expect(result.U(s.W))
+      }
+    }
+  }
+
+  def testAnd(a: Int, b: Int, s: Int): Unit = {
+    val result = (a & b) & mask(s)
+    it should s"& $a, $b and the result == $result" in {
+      test(new Alu(s)) { c =>
+        c.io.fn.poke(3.U)
+        c.io.a.poke(a.U(s.W))
+        c.io.b.poke(b.U(s.W))
+        c.clock.step()
+        c.io.result.expect(result.U(s.W))
+      }
+    }
+  }
+
+  def testSubtraction(a: Int, b: Int, s: Int): Unit = {
+    val result = (a - b) & mask(s)
+    it should s"- $a, $b and the result == $result" in {
+      test(new Alu(s)) { c =>
+        c.io.fn.poke(1.U)
+        c.io.a.poke(a.U(s.W))
+        c.io.b.poke(b.U(s.W))
+        c.clock.step()
+        c.io.result.expect(result.U(s.W))
+      }
+    }
+  }
+}
+
+
+class AluTest extends AnyFlatSpec with AluBehavior with ChiselScalatestTester with Matchers {
+  behavior of "ALU"
+  val testData: List[(Int, Int)] = List[(Int, Int)](
+    (1, 2),
+    (3, 4),
+    (4, 5)
+  )
+  testData.foreach { data =>
+    it should behave like testAddition(data._1, data._2, 4)
+    it should behave like testSubtraction(data._1, data._2, 4)
+    it should behave like testOr(data._1, data._2, 4)
+    it should behave like testAnd(data._1, data._2, 4)
+  }
+}

--- a/src/test/scala/chiseltest/tests/TestUtils.scala
+++ b/src/test/scala/chiseltest/tests/TestUtils.scala
@@ -54,3 +54,23 @@ final class CustomBundle(elts: (String, Data)*) extends Record {
     (new CustomBundle(cloned: _*)).asInstanceOf[this.type]
   }
 }
+/** taken from https://github.com/schoeberl/chisel-examples/blob/master/src/main/scala/simple/Alu.scala */
+class Alu(size: Int) extends Module {
+  val io = IO(new Bundle {
+    val fn = Input(UInt(2.W))
+    val a = Input(UInt(size.W))
+    val b = Input(UInt(size.W))
+    val result = Output(UInt(size.W))
+  })
+
+  val result = Wire(UInt(size.W))
+  result := 0.U
+
+  switch(io.fn) {
+    is(0.U) { result := io.a + io.b }
+    is(1.U) { result := io.a - io.b }
+    is(2.U) { result := io.a | io.b }
+    is(3.U) { result := io.a & io.b }
+  }
+  io.result := result
+}


### PR DESCRIPTION
This pull request adds a simple example of how scalatest enables the possibility to "share" the same test for different data.
The ALU example was taken from [chisel-examples](https://github.com/schoeberl/chisel-examples/blob/master/src/main/scala/simple/Alu.scala)
[Here](https://www.scalatest.org/user_guide/sharing_tests) is the official documentation from scaltest.

Test output
```
[info] AluTest:
[info] ALU
[info] - should + 1, 2 and the result == 3
[info] - should - 1, 2 and the result == 15
[info] - should | 1, 2 and the result == 3
[info] - should & 1, 2 and the result == 0
[info] - should + 3, 4 and the result == 7
[info] - should - 3, 4 and the result == 15
[info] - should | 3, 4 and the result == 7
[info] - should & 3, 4 and the result == 0
[info] - should + 4, 5 and the result == 9
[info] - should - 4, 5 and the result == 15
[info] - should | 4, 5 and the result == 5
[info] - should & 4, 5 and the result == 4
[info] ScalaTest
[info] Run completed in 7 seconds, 946 milliseconds.
[info] Total number of tests run: 12
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 12, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.

```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
### Why I think this is a good addition for the examples in chisel-tester2.

This test by itself is nothing interesting, but is the first step for achieving CRV(Constrained Random Verification) in Chisel.
For example, we can obtain the same behaviour described in  [ASIC WORLD Random Constraints Tutorial - part 6.](http://www.asic-world.com/systemverilog/random_constraint6.html) by combining a CSP solver like [Choco Solver](https://github.com/chocoteam/choco-solver) and Tester2 to test a set of data.

by adding
```
 "org.choco-solver" % "choco-solver" % "4.10.2"
```
to the library dependency in `build.sbt` and changing the code in `AluTest.scala`

```scala
class AluTest extends AnyFlatSpec with AluBehavior with ChiselScalatestTester with Matchers {
  behavior of "ALU"

  val model = new Model("Constraint problem")
  val bit_domain = (0x0 to 0xFF).toArray
  val src_port_domain = (0x0 to 0x0A) ++ Set(0x14, 0x18) toArray
  val src_dest_domain = (0x0 to 0xFF).toSet.diff(0x04 to 0xFF toSet).toArray

  val src_port = model.intVar("src_port", bit_domain)
  val src_dest = model.intVar("src_dest", bit_domain)

  model.member(src_port, src_port_domain).post()
  model.member(src_dest, src_dest_domain).post()
  val solver = model.getSolver
  val sol_port = ArrayBuffer[Int]()
  val sol_dest = ArrayBuffer[Int]()

  while(solver.solve()) {
    it should behave like testAddition(src_port.getValue, src_dest.getValue, 10)
    it should behave like testSubtraction(src_port.getValue, src_dest.getValue, 10)
    it should behave like testOr(src_port.getValue, src_dest.getValue, 10)
    it should behave like testAnd(src_port.getValue, src_dest.getValue, 10)
  }
}
```

We obtain the same result shown in [ASIC WORLD Random Constraints Tutorial - part 6.](http://www.asic-world.com/systemverilog/random_constraint6.html) without code duplication.

The interface to Choco solver is not very friendly and the idea is to create a wrapper for it or to write a simple CSP from scratch in scala similar to the one used in [cocotb-coverage](https://github.com/mciepluc/cocotb-coverage).

Keep up with the good work :smiley: 
Cheers,
Enrico