### PR TITLE
This PR moves project to Apache 2.0 LICENSE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
   Seq() ++ {
@@ -55,13 +55,13 @@ pomIncludeRepository := { x => false }
 
 pomExtra := (
 <url>http://chisel.eecs.berkeley.edu/</url>
-<licenses>
-  <license>
-    <name>BSD-style</name>
-    <url>http://www.opensource.org/licenses/bsd-license.php</url>
-    <distribution>repo</distribution>
-  </license>
-</licenses>
+  <licenses>
+    <license>
+      <name>apache_v2</name>
+      <url>https://opensource.org/licenses/Apache-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 <scm>
   <url>https://github.com/ucb-bar/chisel-testers2.git</url>
   <connection>scm:git:github.com/ucb-bar/chisel-testers2.git</connection>

--- a/build.sc
+++ b/build.sc
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import mill._
 import mill.scalalib._
 import mill.scalalib.publish._

--- a/src/main/scala/chisel3/tester/TestAdapters.scala
+++ b/src/main/scala/chisel3/tester/TestAdapters.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chisel3.tester
 

--- a/src/main/scala/chisel3/tester/package.scala
+++ b/src/main/scala/chisel3/tester/package.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chisel3
 

--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/ChiselUtestTester.scala
+++ b/src/main/scala/chiseltest/ChiselUtestTester.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest
 
 import chiseltest.internal._

--- a/src/main/scala/chiseltest/DecoupledDriver.scala
+++ b/src/main/scala/chiseltest/DecoupledDriver.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/RawTester.scala
+++ b/src/main/scala/chiseltest/RawTester.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/Region.scala
+++ b/src/main/scala/chiseltest/Region.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/ValidDriver.scala
+++ b/src/main/scala/chiseltest/ValidDriver.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/backends/BackendExecutive.scala
+++ b/src/main/scala/chiseltest/backends/BackendExecutive.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.backends
 

--- a/src/main/scala/chiseltest/backends/treadle/OptionsAdapter.scala
+++ b/src/main/scala/chiseltest/backends/treadle/OptionsAdapter.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.backends.treadle
 

--- a/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.backends.treadle
 

--- a/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.backends.treadle
 

--- a/src/main/scala/chiseltest/defaults.scala
+++ b/src/main/scala/chiseltest/defaults.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/exceptions.scala
+++ b/src/main/scala/chiseltest/exceptions.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/experimental/Async.scala
+++ b/src/main/scala/chiseltest/experimental/Async.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.experimental
 

--- a/src/main/scala/chiseltest/experimental/ChiselTestShell.scala
+++ b/src/main/scala/chiseltest/experimental/ChiselTestShell.scala
@@ -1,18 +1,4 @@
-/*
-Copyright 2020 The Regents of the University of California (Regents)
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.experimental
 

--- a/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.experimental
 

--- a/src/main/scala/chiseltest/experimental/UncheckedClockPeek.scala
+++ b/src/main/scala/chiseltest/experimental/UncheckedClockPeek.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.experimental
 

--- a/src/main/scala/chiseltest/experimental/UncheckedClockPoke.scala
+++ b/src/main/scala/chiseltest/experimental/UncheckedClockPoke.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.experimental
 

--- a/src/main/scala/chiseltest/experimental/package.scala
+++ b/src/main/scala/chiseltest/experimental/package.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest
 

--- a/src/main/scala/chiseltest/internal/BackendInterface.scala
+++ b/src/main/scala/chiseltest/internal/BackendInterface.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.internal
 

--- a/src/main/scala/chiseltest/internal/TestEnvInterface.scala
+++ b/src/main/scala/chiseltest/internal/TestEnvInterface.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.internal
 

--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.internal
 

--- a/src/main/scala/chiseltest/internal/ThreadedBackend.scala
+++ b/src/main/scala/chiseltest/internal/ThreadedBackend.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.internal
 

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsAnnotations.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsAnnotations.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.legacy.backends.vcs
 

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.legacy.backends.vcs
 

--- a/src/main/scala/chiseltest/legacy/backends/verilator/CommandEditor.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/CommandEditor.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.legacy.backends.verilator
 

--- a/src/main/scala/chiseltest/legacy/backends/verilator/SimApiInterface.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/SimApiInterface.scala
@@ -1,4 +1,5 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.legacy.backends.verilator
 
 import java.io.File

--- a/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.legacy.backends.verilator
 

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorAnnotations.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorAnnotations.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.legacy.backends.verilator
 

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.legacy.backends.verilator
 

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 import scala.language.implicitConversions
 import chiseltest.internal._

--- a/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
@@ -1,18 +1,4 @@
-/*
-Copyright 2020 The Regents of the University of California (Regents)
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.experimental.tests
 

--- a/src/test/scala/chiseltest/experimental/tests/VcsBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VcsBasicTests.scala
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package chisel3.experimental.tests
 
 import chisel3._

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorBasicTests.scala
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package chiseltest.experimental.tests
 
 import chisel3._

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorClockPokeTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorClockPokeTest.scala
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package chiseltest.experimental.tests
 
 import chisel3._

--- a/src/test/scala/chiseltest/tests/AsyncClockTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncClockTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import chisel3._

--- a/src/test/scala/chiseltest/tests/AsyncResetTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncResetTest.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.tests
 

--- a/src/test/scala/chiseltest/tests/AsyncResetUsingBlackBoxTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncResetUsingBlackBoxTest.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.tests
 

--- a/src/test/scala/chiseltest/tests/BasicTest.scala
+++ b/src/test/scala/chiseltest/tests/BasicTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/BoreTest.scala
+++ b/src/test/scala/chiseltest/tests/BoreTest.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.tests
 

--- a/src/test/scala/chiseltest/tests/BundleLiteralsSpec.scala
+++ b/src/test/scala/chiseltest/tests/BundleLiteralsSpec.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ChiselEnumTest.scala
+++ b/src/test/scala/chiseltest/tests/ChiselEnumTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ClockCrossingTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockCrossingTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ClockDividerTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockDividerTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ClockPeekTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockPeekTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ClockPokeTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockPokeTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/CombinationalPathTest.scala
+++ b/src/test/scala/chiseltest/tests/CombinationalPathTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ElementTest.scala
+++ b/src/test/scala/chiseltest/tests/ElementTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ExceptionPropagationTest.scala
+++ b/src/test/scala/chiseltest/tests/ExceptionPropagationTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultDecoderTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import chisel3._

--- a/src/test/scala/chiseltest/tests/FaultLocatorTest.scala
+++ b/src/test/scala/chiseltest/tests/FaultLocatorTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._
@@ -15,7 +17,7 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
       test(new StaticModule(42.U)) { c =>
         c.out.expect(0.U)
       }
-    }.failedCodeFileNameAndLineNumberString.get should equal ("FaultLocatorTest.scala:16")
+    }.failedCodeFileNameAndLineNumberString.get should equal ("FaultLocatorTest.scala:18")
   }
 
   it should "locate source lines across threads" in {
@@ -27,7 +29,7 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
         }.join()
       }
     }
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*24.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*26.*\)""")
   }
 
   it should "locate source lines in libraries" in {
@@ -43,7 +45,7 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
     }
     // Only check the filename to avoid this being too brittle as implementation changes
     exc.failedCodeFileNameAndLineNumberString.get should startWith ("DecoupledDriver.scala:")
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*41.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*43.*\)""")
   }
 
   it should "locate source lines, even in a different thread" in {
@@ -60,6 +62,6 @@ class FaultLocatorTest extends AnyFlatSpec with ChiselScalatestTester with Match
       }
     }
     exc.failedCodeFileNameAndLineNumberString.get should startWith ("DecoupledDriver.scala:")
-    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*58.*\)""")
+    exc.getMessage should include regex ("""\(lines in FaultLocatorTest\.scala:[^\)]*60.*\)""")
   }
 }

--- a/src/test/scala/chiseltest/tests/NoScalatestTesterTest.scala
+++ b/src/test/scala/chiseltest/tests/NoScalatestTesterTest.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.tests
 

--- a/src/test/scala/chiseltest/tests/OptionsBackwardCompatibilityTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsBackwardCompatibilityTest.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.tests
 

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import java.io.{ByteArrayOutputStream, File, PrintStream}

--- a/src/test/scala/chiseltest/tests/QueueTest.scala
+++ b/src/test/scala/chiseltest/tests/QueueTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/RegionsTest.scala
+++ b/src/test/scala/chiseltest/tests/RegionsTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ShiftRegisterTest.scala
+++ b/src/test/scala/chiseltest/tests/ShiftRegisterTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/TestUtils.scala
+++ b/src/test/scala/chiseltest/tests/TestUtils.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import chisel3._

--- a/src/test/scala/chiseltest/tests/ThreadJoinTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadJoinTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/ThreadSafetyLocatorTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadSafetyLocatorTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import chisel3._
@@ -22,7 +24,7 @@ class ThreadSafetyLocatorTest extends AnyFlatSpec with ChiselScalatestTester {
         }.join
       }
     }.getMessage()
-    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:20")
-    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:17")
+    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:22")
+    exceptionMessage should include ("ThreadSafetyLocatorTest.scala:19")
   }
 }

--- a/src/test/scala/chiseltest/tests/ThreadSafetyTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadSafetyTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/TimeoutTest.scala
+++ b/src/test/scala/chiseltest/tests/TimeoutTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/TimescopeTest.scala
+++ b/src/test/scala/chiseltest/tests/TimescopeTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import org.scalatest._

--- a/src/test/scala/chiseltest/tests/UtestTesterTest.scala
+++ b/src/test/scala/chiseltest/tests/UtestTesterTest.scala
@@ -1,4 +1,4 @@
-// See LICENSE for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.tests
 

--- a/src/test/scala/chiseltest/tests/ValidQueueTest.scala
+++ b/src/test/scala/chiseltest/tests/ValidQueueTest.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiseltest.tests
 
 import chisel3._

--- a/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
+++ b/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
@@ -1,4 +1,4 @@
-// See README.md for license details.
+// SPDX-License-Identifier: Apache-2.0
 
 package chiseltest.tests
 


### PR DESCRIPTION
All source files have been changed to use
SPDX license: https://spdx.org/licenses/
Also changed build.sbt and build.sc
Several test that had specific line numbers
referenced that were moved because of new license
were also fixed