### PR TITLE
Deprecated Annotations were causing annoying warnings

### DIFF
--- a/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
@@ -8,7 +8,7 @@ import chisel3.experimental.DataMirror
 import chisel3.MultiIOModule
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import firrtl.annotations.ReferenceTarget
-import firrtl.stage.CompilerAnnotation
+import firrtl.stage.RunFirrtlTransformAnnotation
 import firrtl.transforms.{CheckCombLoops, CombinationalPath}
 import treadle.stage.TreadleTesterPhase
 import treadle.{TreadleCircuitStateAnnotation, TreadleFirrtlFormHint, TreadleTesterAnnotation}
@@ -41,10 +41,10 @@ object TreadleExecutive extends BackendExecutive {
     }.toMap
 
     // This generates the firrtl circuit needed by the TreadleTesterPhase
-    annotationSeq = (new ChiselStage).run(annotationSeq ++ Seq(CompilerAnnotation(new LowFirrtlCompiler)))
+    annotationSeq = (new ChiselStage).run(annotationSeq ++ Seq(RunFirrtlTransformAnnotation(new LowFirrtlEmitter)))
 
     // This generates a TreadleTesterAnnotation with a treadle tester instance
-    annotationSeq = (new TreadleTesterPhase).transform(annotationSeq :+ TreadleFirrtlFormHint(LowForm))
+    annotationSeq = (new TreadleTesterPhase).transform(annotationSeq)
 
     val treadleTester = annotationSeq.collectFirst { case TreadleTesterAnnotation(t) => t }.getOrElse(
       throw new Exception(

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
@@ -8,7 +8,7 @@ import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import chiseltest.internal.BackendInstance
 import chiseltest.backends.BackendExecutive
 import firrtl.annotations.{DeletedAnnotation, ReferenceTarget}
-import firrtl.stage.CompilerAnnotation
+import firrtl.stage.RunFirrtlTransformAnnotation
 import firrtl.transforms.CombinationalPath
 
 object VcsExecutive extends BackendExecutive {
@@ -38,7 +38,7 @@ object VcsExecutive extends BackendExecutive {
     System.gc()
 
     val targetDir = annotationSeq.collectFirst {
-      case TargetDirAnnotation(t) => t
+      case firrtl.options.TargetDirAnnotation(t) => t
     }.get
     val targetDirFile = new File(targetDir)
 
@@ -63,7 +63,7 @@ object VcsExecutive extends BackendExecutive {
       .run(
         annotationSeq ++ Seq(
           generatorAnnotation,
-          CompilerAnnotation(new VerilogCompiler())
+          RunFirrtlTransformAnnotation(new VerilogEmitter)
         )
       )
       .filterNot(_.isInstanceOf[DeletedAnnotation])

--- a/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
@@ -98,7 +98,7 @@ trait EditableBuildCSimulatorCommand {
     * @return sequence of strings (suitable for passing as arguments to the simulator builder) specifying a flag and the absolute path to the file.
     */
   def blackBoxVerilogList(dir: java.io.File): Seq[String] = {
-    val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.fileListName)
+    val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.defaultFileListName)
     if(list_file.exists()) {
       Seq("-f", list_file.getAbsolutePath)
     } else {


### PR DESCRIPTION
Remove deprecated Annotations from BackendExecutives in RC3
Users have complained
- CompilerAnnotation
- TreadleFormHint
- chisel3.Driver.cppToExe
Fix path on TargetDirAnnotation usage to avoid deprecation warnings
Changed BlackBoxSourceHelper.fileListName to BlackBoxSourceHelper.defaultFileListName