### PR TITLE
Remove scalatest Assertions from RawTester

### DIFF
--- a/src/main/scala/chiseltest/RawTester.scala
+++ b/src/main/scala/chiseltest/RawTester.scala
@@ -7,13 +7,12 @@ import chiseltest.experimental.sanitizeFileName
 import chisel3.MultiIOModule
 
 import firrtl.AnnotationSeq
-import org.scalatest._
 
 /**
   * Used to run simple tests that do not require a scalatest environment in order to run
   * @param testName This will be used to generate a working directory in ./test_run_dir
   */
-private class RawTester(testName: String) extends Assertions with TestEnvInterface {
+private class RawTester(testName: String) extends TestEnvInterface {
   // Provide test fixture data as part of 'global' context during test runs
   val topFileName = Some(testName)
 


### PR DESCRIPTION
Possible workaround for #209 - doesn't address the versioning issue, but possibly removes one symptom. Not sure if there's a easy way to test this before this gets published.

No idea why it was there in the first place...