### PR TITLE
Add thread ordering documentation and supporting test

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ See the test cases for examples:
 ## New Constructs
 - `fork` to spawn threads, and `join` to block (wait) on a thread.
   Pokes and peeks/expects to wires from threads are checked during runtime to ensure no collisions or unexpected behavior.
+  - `fork`ed threads provide a concurrency abstraction for writing testbenches only, without real parallelism.
+    The test infrastructure schedules threads one at a time, with threads running once per simulation cycle.
+  - Thread order is deterministic, and attempts to follow lexical order (as it would appear from the code text): `fork`ed (child) threads run immediately, then return to the spawning (parent) thread.
+    On future cycles, child threads run before their parent, in the order they were spawned.
+  - Only cross-thread operations that round-trip through the simulator (eg, peek-after-poke) are checked.
+    You can do cross-thread operations in Scala (eg, using shared variables) that aren't checked, but it is up to you to make sure they are correct and intuitive.
+    This is not recommended.
+    In the future, we may provide checked mechanisms for communicating between test threads.
 - Regions can be associated with a thread, with `fork.withRegion(...)`, which act as a synchronization barrier within simulator time steps.
   This can be used to create monitors that run after other main testdriver threads have been run, and can read wires those threads have poked.
 - `timescope` allows pokes to be scoped - that is, pokes inside the timescope block "disappear" and the wire reverts to its previous value at the end of the block.

--- a/src/test/scala/chiseltest/tests/ThreadOrderTest.scala
+++ b/src/test/scala/chiseltest/tests/ThreadOrderTest.scala
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.tests
+
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class ThreadOrderTest extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "ChiselTest thread ordering"
+
+  it should "run child threads immediately, then on future cycles before parent threads" in {
+    // TODO: can this be done without using shared variables?
+    test(new StaticModule(0.U)) { c =>
+      var flag: Int = 0
+      fork {
+        while (true) {
+          flag += 1
+          c.clock.step(1)
+        }
+      }
+      // Fork runs immediately, increments then blocks
+      assert(flag == 1)
+      c.clock.step(1)
+      // Fork should run before this thread is scheduled
+      assert(flag == 2)
+    }
+  }
+}


### PR DESCRIPTION
As described in the title, adds the fork behavior to the README, and a test for it.

Resolves #202 