### PR TITLE
Add CI for scalafmt

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -96,6 +96,10 @@ jobs:
         run: |
           versionDeps=$(gawk -f repo/.github/scripts/generateVersionOverrides.gawk deps)
           echo "versonDeps: $versionDeps"
+      - name: check-scalafmt
+        id: check-scalafmt
+        run: cat /dev/null | sbt $versionDeps +scalafmtCheckAll
+        working-directory: ./repo
       - name: test
         id: test
         run: cat /dev/null | sbt $versionDeps +test


### PR DESCRIPTION
The forked repo has this [limitation](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories)
So I split this from #198 