### PR TITLE
Update SBT to 1.4.3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.3


### PR DESCRIPTION
Fixes #209

I did some digging, and it turns out that on `master` with SBT `1.3.13`, you can see the error by looking at the `Compile / fullClasspath` vs. the published pom. See discussion here: https://gitter.im/sbt/sbt?at=5fb8374c29cc4d73481fb6b3

I found that updating SBT fixes the issue, the compile classpath and pom are properly in sync.
