### PR TITLE
Pass Coverage Flags to VCS Simulation

### DIFF
--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
@@ -122,7 +122,7 @@ object VcsExecutive extends BackendExecutive {
       .collectFirst[Seq[String]] {
         case TestCommandOverride(f) => f.split(" +")
       }
-      .getOrElse { Seq(new File(targetDir, circuit.name).toString) }
+      .getOrElse { Seq(new File(targetDir, circuit.name).toString) } ++ coverageFlags
 
     val paths = compiledAnnotations.collect { case c: CombinationalPath => c }
 


### PR DESCRIPTION
Adding the missing coverage flag arguments to the VCS simulation command. Without it, the simulation won't monitor for coverage.