### PR TITLE
Fix probable bug in `VcsExecutive`

### DIFF
--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
@@ -103,7 +103,7 @@ object VcsExecutive extends BackendExecutive {
       case CommandEditsFile(fileName) => fileName
     }.getOrElse("")
 
-    val vcsFlags = moreVcsCFlags ++ coverageFlags
+    val vcsFlags = moreVcsFlags ++ coverageFlags
 
     assert(
       VerilogToVcs(


### PR DESCRIPTION
``moreVcsFlags` is now used properly when constructing vcs command line
Looks like typo when coverage flags added
@ryan-lund @TsaiAnson can one of you confirm this looks right now, thanks.