### PR TITLE
Use only a single version of scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.8",
-  "org.scalatest" %% "scalatest" % "3.2.0" % "test",
+  "org.scalatest" %% "scalatest" % "3.2.2",
   "com.lihaoyi" %% "utest" % "latest.integration"
 )
 


### PR DESCRIPTION
Fixes problems found in sbt and intellij when using two different versions