### PR TITLE
Chisel 3.5: MultiIOModule is now just Module

### DIFF
--- a/src/main/scala/chisel3/tester/package.scala
+++ b/src/main/scala/chisel3/tester/package.scala
@@ -57,7 +57,7 @@ package object tester {
     def sanitizeFileName(name: String): String = chiseltest.experimental.sanitizeFileName(name)
 
     object TestOptionBuilder {
-      implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T])
+      implicit class ChiselScalatestOptionBuilder[T <: Module](x: ChiselScalatestTester#TestBuilder[T])
           extends chiseltest.experimental.TestOptionBuilder.ChiselScalatestOptionBuilder[T](x)
     }
 

--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -4,7 +4,7 @@ package chiseltest
 
 import chiseltest.internal._
 import chiseltest.experimental.{sanitizeFileName, ChiselTestShell}
-import chisel3.MultiIOModule
+import chisel3.Module
 import chiseltest.internal.WriteVcdAnnotation
 import firrtl.AnnotationSeq
 import org.scalatest._
@@ -14,7 +14,7 @@ import scala.util.DynamicVariable
 
 trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvInterface { this: TestSuite =>
 
-  class TestBuilder[T <: MultiIOModule](
+  class TestBuilder[T <: Module](
     val dutGen:        () => T,
     val annotationSeq: AnnotationSeq,
     val flags:         Array[String]) {
@@ -54,7 +54,7 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
   // Stack trace data to help generate more informative (and localizable) failure messages
   var topFileName: Option[String] = None // best guess at the testdriver top filename
 
-  private def runTest[T <: MultiIOModule](tester: BackendInstance[T])(testFn: T => Unit) {
+  private def runTest[T <: Module](tester: BackendInstance[T])(testFn: T => Unit) {
     // Try and get the user's top-level test filename
     val internalFiles = Set("ChiselScalatestTester.scala", "BackendInterface.scala", "TestEnvInterface.scala")
     val topFileNameGuess = (new Throwable).getStackTrace.apply(2).getFileName
@@ -104,10 +104,10 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
     * @note This API is experimental and forward compatibility is not yet guaranteed
     *
     * @param dutGen             A generator of a Chisel  Module
-    * @tparam T                 The DUT type, must be a subclass of MultiIOModule
+    * @tparam T                 The DUT type, must be a subclass of Module
     * @return
     */
-  def test[T <: MultiIOModule](dutGen: => T): TestBuilder[T] = {
+  def test[T <: Module](dutGen: => T): TestBuilder[T] = {
     new TestBuilder(() => dutGen, Seq.empty, Array.empty)
   }
 }

--- a/src/main/scala/chiseltest/ChiselUtestTester.scala
+++ b/src/main/scala/chiseltest/ChiselUtestTester.scala
@@ -5,7 +5,7 @@ package chiseltest
 import chiseltest.internal._
 import chiseltest.experimental.sanitizeFileName
 import utest.TestSuite
-import chisel3.MultiIOModule
+import chisel3.Module
 import firrtl.AnnotationSeq
 import utest.framework.Formatter
 
@@ -68,9 +68,9 @@ trait ChiselUtestTester extends TestSuite with TestEnvInterface {
     *
     * @note This API is experimental and forward compatibility is not yet guaranteed
     * @param dutGen A generator of a Chisel Module
-    * @tparam T The DUT type, must be a subclass of MultiIOModule
+    * @tparam T The DUT type, must be a subclass of Module
     */
-  def testCircuit[T <: MultiIOModule](
+  def testCircuit[T <: Module](
     dutGen:        => T,
     annotationSeq: AnnotationSeq = Seq.empty
   )(testFn:        T => Unit

--- a/src/main/scala/chiseltest/RawTester.scala
+++ b/src/main/scala/chiseltest/RawTester.scala
@@ -4,7 +4,7 @@ package chiseltest
 
 import chiseltest.internal._
 import chiseltest.experimental.sanitizeFileName
-import chisel3.MultiIOModule
+import chisel3.Module
 
 import firrtl.AnnotationSeq
 
@@ -16,13 +16,13 @@ private class RawTester(testName: String) extends TestEnvInterface {
   // Provide test fixture data as part of 'global' context during test runs
   val topFileName = Some(testName)
 
-  private def runTest[T <: MultiIOModule](tester: BackendInstance[T])(testFn: T => Unit) {
+  private def runTest[T <: Module](tester: BackendInstance[T])(testFn: T => Unit) {
     batchedFailures.clear()
 
     Context.run(tester, this, testFn)
   }
 
-  def test[T <: MultiIOModule](dutGen: => T, annotationSeq: AnnotationSeq)(testFn: T => Unit) {
+  def test[T <: Module](dutGen: => T, annotationSeq: AnnotationSeq)(testFn: T => Unit) {
     val newAnnos = addDefaultTargetDir(sanitizeFileName(testName), annotationSeq)
     runTest(defaults.createDefaultTester(() => dutGen, newAnnos))(testFn)
   }
@@ -51,7 +51,7 @@ object RawTester {
     * @param testFn    The block of code that implements the test
     * @tparam T        The type of device, derived from dutGen
     */
-  def test[T <: MultiIOModule](dutGen: => T, annotationSeq: AnnotationSeq = Seq.empty)(testFn: T => Unit): Unit = {
+  def test[T <: Module](dutGen: => T, annotationSeq: AnnotationSeq = Seq.empty)(testFn: T => Unit): Unit = {
 
     val testName = s"chisel_test_${System.currentTimeMillis()}"
 

--- a/src/main/scala/chiseltest/backends/BackendExecutive.scala
+++ b/src/main/scala/chiseltest/backends/BackendExecutive.scala
@@ -5,7 +5,7 @@ package chiseltest.backends
 import chiseltest.internal.BackendInstance
 import chisel3.experimental.BaseModule
 import chisel3.internal.firrtl.Circuit
-import chisel3.{Data, Element, MultiIOModule, Record, Vec}
+import chisel3.{Data, Element, Module, Record, Vec}
 import firrtl.AnnotationSeq
 import firrtl.annotations.ReferenceTarget
 import firrtl.transforms.CombinationalPath
@@ -61,5 +61,5 @@ trait BackendExecutive {
     mapPairs.toMap
   }
 
-  def start[T <: MultiIOModule](dutGen: () => T, annotationSeq: AnnotationSeq): BackendInstance[T]
+  def start[T <: Module](dutGen: () => T, annotationSeq: AnnotationSeq): BackendInstance[T]
 }

--- a/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleBackend.scala
@@ -10,7 +10,7 @@ import treadle.TreadleTester
 import scala.collection.mutable
 
 // TODO: is Seq[CombinationalPath] the right API here? It's unclear where name -> Data resolution should go
-class TreadleBackend[T <: MultiIOModule](
+class TreadleBackend[T <: Module](
   val dut:                T,
   val dataNames:          Map[Data, String],
   val combinationalPaths: Map[Data, Set[Data]],

--- a/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
+++ b/src/main/scala/chiseltest/backends/treadle/TreadleExecutive.scala
@@ -5,7 +5,7 @@ package chiseltest.backends.treadle
 import chiseltest.backends.BackendExecutive
 import chiseltest.internal._
 import chisel3.experimental.DataMirror
-import chisel3.MultiIOModule
+import chisel3.Module
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import firrtl.annotations.ReferenceTarget
 import firrtl.stage.RunFirrtlTransformAnnotation
@@ -20,7 +20,7 @@ object TreadleExecutive extends BackendExecutive {
     component.name
   }
 
-  def start[T <: MultiIOModule](dutGen: () => T, testersAnnotationSeq: AnnotationSeq): BackendInstance[T] = {
+  def start[T <: Module](dutGen: () => T, testersAnnotationSeq: AnnotationSeq): BackendInstance[T] = {
 
     // Force a cleanup: long SBT runs tend to fail with memory issues
     System.gc()

--- a/src/main/scala/chiseltest/defaults.scala
+++ b/src/main/scala/chiseltest/defaults.scala
@@ -3,7 +3,7 @@
 package chiseltest
 
 import chiseltest.internal._
-import chisel3.MultiIOModule
+import chisel3.Module
 import firrtl.AnnotationSeq
 
 package object defaults {
@@ -16,7 +16,7 @@ package object defaults {
     * @tparam T              dut type
     * @return                a backend for the dut type
     */
-  def createDefaultTester[T <: MultiIOModule](dutGen: () => T, annotationSeq: AnnotationSeq): BackendInstance[T] = {
+  def createDefaultTester[T <: Module](dutGen: () => T, annotationSeq: AnnotationSeq): BackendInstance[T] = {
     val backend = annotationSeq.collectFirst {
       case x: BackendAnnotation => x
     }.getOrElse(TreadleBackendAnnotation)

--- a/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
+++ b/src/main/scala/chiseltest/experimental/TestOptionBuilder.scala
@@ -20,7 +20,7 @@ import firrtl.{
 }
 
 package object TestOptionBuilder {
-  implicit class ChiselScalatestOptionBuilder[T <: MultiIOModule](x: ChiselScalatestTester#TestBuilder[T]) {
+  implicit class ChiselScalatestOptionBuilder[T <: Module](x: ChiselScalatestTester#TestBuilder[T]) {
     def withAnnotations(annotationSeq: AnnotationSeq): ChiselScalatestTester#TestBuilder[T] = {
       new x.outer.TestBuilder[T](x.dutGen, x.annotationSeq ++ annotationSeq, x.flags)
     }

--- a/src/main/scala/chiseltest/internal/BackendInterface.scala
+++ b/src/main/scala/chiseltest/internal/BackendInterface.scala
@@ -113,7 +113,7 @@ trait BackendInterface {
 
 /** Backend associated with a particular circuit, and can run tests
   */
-trait BackendInstance[T <: MultiIOModule] extends BackendInterface {
+trait BackendInstance[T <: Module] extends BackendInterface {
 
   /** Runs of tests are wrapped in this, for any special setup/teardown that needs to happen.
     * Takes the test function, which takes the module used as the testing interface.

--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -2,7 +2,7 @@
 
 package chiseltest.internal
 
-import chisel3.MultiIOModule
+import chisel3.Module
 import chiseltest.backends.BackendExecutive
 import chiseltest.backends.treadle.TreadleExecutive
 import chiseltest.legacy.backends.vcs.VcsExecutive
@@ -152,7 +152,7 @@ object Context {
 
   private var context = new DynamicVariable[Option[Instance]](None)
 
-  def run[T <: MultiIOModule](backend: BackendInstance[T], env: TestEnvInterface, testFn: T => Unit) {
+  def run[T <: Module](backend: BackendInstance[T], env: TestEnvInterface, testFn: T => Unit) {
     require(context.value.isEmpty)
     context.withValue(Some(new Instance(backend, env))) {
       backend.run(testFn)

--- a/src/main/scala/chiseltest/internal/ThreadedBackend.scala
+++ b/src/main/scala/chiseltest/internal/ThreadedBackend.scala
@@ -36,7 +36,7 @@ case class ForkBuilder(name: Option[String], region: Option[Region], threads: Se
   * - runThreads: runs all threads waiting on a set of clocks
   * - scheduler: called from within a test thread, suspends the current thread and runs the next one
   */
-trait ThreadedBackend[T <: MultiIOModule] extends BackendInterface {
+trait ThreadedBackend[T <: Module] extends BackendInterface {
   def dut: T
 
   // State for deadlock detection timeout

--- a/src/main/scala/chiseltest/legacy/backends/vcs/GenVcsVerilogHarness.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/GenVcsVerilogHarness.scala
@@ -11,7 +11,7 @@ import chiseltest.legacy.backends.verilator.getDataNames
   */
 object GenVcsVerilogHarness {
 
-  def getPorts(dut: MultiIOModule, separator: String = "."): (Seq[(Element, String)], Seq[(Element, String)]) = {
+  def getPorts(dut: Module, separator: String = "."): (Seq[(Element, String)], Seq[(Element, String)]) = {
     getDataNames(dut, separator).partition { case (e, _) => DataMirror.directionOf(e) == ActualDirection.Input }
   }
 
@@ -30,7 +30,7 @@ object GenVcsVerilogHarness {
     )
   }
 
-  def apply(dut: MultiIOModule, writer: Writer, vpdFilePath: String, isGateLevel: Boolean = false) {
+  def apply(dut: Module, writer: Writer, vpdFilePath: String, isGateLevel: Boolean = false) {
     val dutName = dut.name
     // getPorts() is going to return names prefixed with the dut name.
     // These don't correspond to code currently generated for verilog modules,

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
@@ -13,7 +13,7 @@ import chiseltest.legacy.backends.verilator.VerilatorBackend
   * @param command              the simulation program to execute
   * @tparam T                   the dut's type
   */
-class VcsBackend[T <: MultiIOModule](
+class VcsBackend[T <: Module](
   dut:                T,
   dataNames:          Map[Data, String],
   combinationalPaths: Map[Data, Set[Data]],

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsExecutive.scala
@@ -29,7 +29,7 @@ object VcsExecutive extends BackendExecutive {
     }
   }
 
-  def start[T <: MultiIOModule](
+  def start[T <: Module](
     dutGen:        () => T,
     annotationSeq: AnnotationSeq
   ): BackendInstance[T] = {

--- a/src/main/scala/chiseltest/legacy/backends/verilator/SimApiInterface.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/SimApiInterface.scala
@@ -20,7 +20,7 @@ import scala.language.implicitConversions
   * @param dut  The device under test
   * @param cmd  The command to run as a Seq of strings
   */
-private[chiseltest] class SimApiInterface(dut: MultiIOModule, cmd: Seq[String]) extends LazyLogging {
+private[chiseltest] class SimApiInterface(dut: Module, cmd: Seq[String]) extends LazyLogging {
   //
   // Construct maps for the input and output
   // Remove zero length fields during the process

--- a/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
@@ -25,7 +25,7 @@ private[chiseltest] object getDataNames {
     case b: Record  => b.elements.toSeq.flatMap { case (n, e) => apply(s"${name}_$n", e) }
     case v: Vec[_]  => v.zipWithIndex.flatMap { case (e, i) => apply(s"${name}_$i", e) }
   }
-  def apply(dut: MultiIOModule, separator: String = "."): Seq[(Element, String)] =
+  def apply(dut: Module, separator: String = "."): Seq[(Element, String)] =
     dut.getPorts.flatMap {
       case chisel3.internal.firrtl.Port(data, _) =>
         apply(data.pathName.replace(".", separator), data)
@@ -34,7 +34,7 @@ private[chiseltest] object getDataNames {
 }
 
 private[chiseltest] object getPorts {
-  def apply(dut: MultiIOModule, separator: String = "."): (Seq[(Element, String)], Seq[(Element, String)]) =
+  def apply(dut: Module, separator: String = "."): (Seq[(Element, String)], Seq[(Element, String)]) =
     getDataNames(dut, separator).partition { case (e, _) => DataMirror.directionOf(e) == ActualDirection.Input }
 }
 

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorBackend.scala
@@ -21,7 +21,7 @@ import scala.math.BigInt
   * @tparam T                   the dut's type
   */
 // TODO: is Seq[CombinationalPath] the right API here? It's unclear where name -> Data resolution should go
-class VerilatorBackend[T <: MultiIOModule](
+class VerilatorBackend[T <: Module](
   val dut:                T,
   val dataNames:          Map[Data, String],
   val combinationalPaths: Map[Data, Set[Data]],

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorCppHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorCppHarnessGenerator.scala
@@ -1,13 +1,13 @@
 package chiseltest.legacy.backends.verilator
 
-import chisel3.MultiIOModule
+import chisel3.Module
 import scala.sys.process._
 
 /**
   * Generates the Module specific verilator harness cpp file for verilator compilation
   */
 object VerilatorCppHarnessGenerator {
-  def codeGen(dut: MultiIOModule, vcdFilePath: String, targetDir: String): String = {
+  def codeGen(dut: Module, vcdFilePath: String, targetDir: String): String = {
     val codeBuffer = new StringBuilder
 
     def pushBack(vector: String, pathName: String, width: BigInt) {

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -4,7 +4,7 @@ import java.io.{File, FileWriter}
 
 import chiseltest.backends.BackendExecutive
 import chiseltest.internal._
-import chisel3.{assert, MultiIOModule}
+import chisel3.{assert, Module}
 import chisel3.experimental.DataMirror
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
 import firrtl.annotations.ReferenceTarget
@@ -30,7 +30,7 @@ object VerilatorExecutive extends BackendExecutive {
     }
   }
 
-  def start[T <: MultiIOModule](
+  def start[T <: Module](
     dutGen:        () => T,
     annotationSeq: AnnotationSeq
   ): BackendInstance[T] = {

--- a/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
@@ -8,7 +8,7 @@ import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.internal.VerilatorBackendAnnotation
 import org.scalatest.freespec.AnyFreeSpec
 
-class HasOddWidthSInt extends MultiIOModule {
+class HasOddWidthSInt extends Module {
   val in = IO(Input(SInt(15.W)))
   val out = IO(Output(Bool()))
 

--- a/src/test/scala/chiseltest/experimental/tests/VcsCoverageTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VcsCoverageTests.scala
@@ -19,7 +19,7 @@ class VcsCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Match
 
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VcsBackendAnnotation, LineCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VcsBackendAnnotation, LineCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     output.contains("-cm line") should be(true)
@@ -30,7 +30,7 @@ class VcsCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Match
 
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VcsBackendAnnotation, ToggleCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VcsBackendAnnotation, ToggleCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     output.contains("-cm tgl") should be(true)
@@ -41,7 +41,7 @@ class VcsCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Match
 
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VcsBackendAnnotation, BranchCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VcsBackendAnnotation, BranchCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     output.contains("-cm branch") should be(true)
@@ -52,7 +52,7 @@ class VcsCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Match
 
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule() {}).withAnnotations(Seq(VcsBackendAnnotation, ConditionalCoverageAnnotation)) { c => }
+      test(new Module() {}).withAnnotations(Seq(VcsBackendAnnotation, ConditionalCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     output.contains("-cm cond") should be(true)
@@ -63,7 +63,7 @@ class VcsCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Match
 
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VcsBackendAnnotation, StructuralCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VcsBackendAnnotation, StructuralCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     output.contains("-cm line+tgl+branch+cond") should be(true)
@@ -74,7 +74,7 @@ class VcsCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Match
 
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VcsBackendAnnotation, UserCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VcsBackendAnnotation, UserCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     output.contains("-cm assert") should be(true)
@@ -85,7 +85,7 @@ class VcsCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Match
 
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VcsBackendAnnotation, UserCoverageAnnotation, StructuralCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VcsBackendAnnotation, UserCoverageAnnotation, StructuralCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     output.contains("-cm line+tgl+branch+cond+assert") should be(true)

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorClockPokeTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorClockPokeTest.scala
@@ -16,7 +16,7 @@ class VerilatorClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with a clock input"
 
   it should "verilator-clock-poke" in {
-    test(new MultiIOModule {
+    test(new Module {
       val inClock = IO(Input(Clock()))
       val out = IO(Output(UInt(8.W)))
 
@@ -53,7 +53,7 @@ class VerilatorClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
   }
 
   it should "clock-as-bool-verilator-clock-poke" in {
-    test(new MultiIOModule {
+    test(new Module {
       val inClock = IO(Input(Bool()))
       val out = IO(Output(UInt(8.W)))
 
@@ -78,7 +78,7 @@ class VerilatorClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
   }
 
   it should "treadle-clock-poke" in {
-    test(new MultiIOModule {
+    test(new Module {
       val inClock = IO(Input(Clock()))
       val out = IO(Output(UInt(8.W)))
 

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorCoverageTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorCoverageTests.scala
@@ -19,7 +19,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     val coverage = new File(coverageName)
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VerilatorBackendAnnotation, ToggleCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VerilatorBackendAnnotation, ToggleCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     coverage.exists() should be(true)
@@ -33,7 +33,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     val coverage = new File(coverageName)
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VerilatorBackendAnnotation, LineCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VerilatorBackendAnnotation, LineCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     coverage.exists() should be(true)
@@ -47,7 +47,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     val coverage = new File(coverageName)
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VerilatorBackendAnnotation, StructuralCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VerilatorBackendAnnotation, StructuralCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     coverage.exists() should be(true)
@@ -61,7 +61,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     val coverage = new File(coverageName)
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VerilatorBackendAnnotation, UserCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VerilatorBackendAnnotation, UserCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     coverage.exists() should be(true)
@@ -75,7 +75,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     val coverage = new File(coverageName)
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VerilatorBackendAnnotation, UserCoverageAnnotation, StructuralCoverageAnnotation)) { c => }
+      test(new Module {}).withAnnotations(Seq(VerilatorBackendAnnotation, UserCoverageAnnotation, StructuralCoverageAnnotation)) { c => }
     }
     val output = outputStream.toString
     coverage.exists() should be(true)

--- a/src/test/scala/chiseltest/tests/AsyncClockTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncClockTest.scala
@@ -11,7 +11,7 @@ class AsyncClockTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with clock crossing signals"
 
   it should "work with async clock signals" in {
-    test(new MultiIOModule {
+    test(new Module {
       val inClk = IO(Input(Bool()))
       val in = IO(Input(UInt(8.W)))
       val out = IO(Output(UInt(8.W)))
@@ -48,7 +48,7 @@ class AsyncClockTest extends AnyFlatSpec with ChiselScalatestTester {
   }
 
   it should "work with async clock and reset signals" in {
-    test(new MultiIOModule {
+    test(new Module {
       val inClk = IO(Input(Bool()))
       val inRst = IO(Input(Bool()))
       val in = IO(Input(UInt(8.W)))

--- a/src/test/scala/chiseltest/tests/AsyncResetTest.scala
+++ b/src/test/scala/chiseltest/tests/AsyncResetTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.freespec.AnyFreeSpec
   * circuit that illustrates usage of async register
   * @param resetValue value on reset
   */
-class AsyncResetRegModule(resetValue: Int) extends MultiIOModule {
+class AsyncResetRegModule(resetValue: Int) extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(8.W))
     val out = Output(UInt(8.W))
@@ -27,7 +27,7 @@ class AsyncResetRegModule(resetValue: Int) extends MultiIOModule {
 
 }
 
-class AsyncResetFeedbackModule() extends MultiIOModule {
+class AsyncResetFeedbackModule() extends Module {
   val io = IO(new Bundle {
     val out = Output(Vec(2, UInt(1.W)))
   })

--- a/src/test/scala/chiseltest/tests/BoreTest.scala
+++ b/src/test/scala/chiseltest/tests/BoreTest.scala
@@ -11,17 +11,17 @@ import org.scalatest.matchers.should.Matchers
 class BoreTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
-  class Constant extends MultiIOModule {
+  class Constant extends Module {
     val x = Reg(UInt(6.W))
     x := 42.U
   }
 
-  class Expect extends MultiIOModule {
+  class Expect extends Module {
     val y = IO(Output(UInt(6.W)))
     y := 0.U
   }
 
-  class Top extends MultiIOModule {
+  class Top extends Module {
     val y = IO(Output(UInt(6.W)))
     val constant = Module(new Constant)
     val expect = Module(new Expect)

--- a/src/test/scala/chiseltest/tests/ClockPeekTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockPeekTest.scala
@@ -14,7 +14,7 @@ class ClockPeekTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with clock peeking"
 
   it should "work as expected" in {
-    test(new MultiIOModule {
+    test(new Module {
       val inClock = IO(Input(Clock()))
       val outClock = IO(Output(Clock()))
       outClock := inClock

--- a/src/test/scala/chiseltest/tests/ClockPokeTest.scala
+++ b/src/test/scala/chiseltest/tests/ClockPokeTest.scala
@@ -14,7 +14,7 @@ class ClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with a clock input"
 
   it should "work as expected" in {
-    test(new MultiIOModule {
+    test(new Module {
       val inClock = IO(Input(Clock()))
       val out = IO(Output(UInt(8.W)))
 

--- a/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
+++ b/src/test/scala/chiseltest/tests/OptionsPassingTest.scala
@@ -53,7 +53,7 @@ class OptionsPassingTest extends AnyFlatSpec with ChiselScalatestTester with Mat
     if (targetDir.exists()) {
       targetDir.delete()
     }
-    test(new MultiIOModule() {}).withFlags(Array("--target-dir", targetDirName)) { c =>
+    test(new Module() {}).withFlags(Array("--target-dir", targetDirName)) { c =>
       targetDir.exists() should be(true)
     }
   }
@@ -73,7 +73,7 @@ class OptionsPassingTest extends AnyFlatSpec with ChiselScalatestTester with Mat
     if (targetDir.exists()) {
       targetDir.delete()
     }
-    test(new MultiIOModule() {})
+    test(new Module() {})
       .withAnnotations(annotations)
       .withFlags(Array("--target-dir", targetDirName)) { c =>
         targetDir.exists() should be(true)
@@ -85,7 +85,7 @@ class OptionsPassingTest extends AnyFlatSpec with ChiselScalatestTester with Mat
   it should "allow turning on verbose mode" in {
     val outputStream = new ByteArrayOutputStream()
     Console.withOut(new PrintStream(outputStream)) {
-      test(new MultiIOModule {}).withAnnotations(Seq(VerboseAnnotation)) { c =>
+      test(new Module {}).withAnnotations(Seq(VerboseAnnotation)) { c =>
         c.clock.step(1)
       }
     }

--- a/src/test/scala/chiseltest/tests/TestUtils.scala
+++ b/src/test/scala/chiseltest/tests/TestUtils.scala
@@ -9,34 +9,34 @@ import chisel3.util._
 
 import scala.collection.immutable.ListMap
 
-class StaticModule[T <: Data](ioLit: T) extends MultiIOModule {
+class StaticModule[T <: Data](ioLit: T) extends Module {
   val out = IO(Output(chiselTypeOf(ioLit)))
   out := ioLit
 }
 
-class InputOnlyModule[T <: Data](ioType: T) extends MultiIOModule {
+class InputOnlyModule[T <: Data](ioType: T) extends Module {
   val in = IO(Input(ioType))
 }
 
-class PassthroughModule[T <: Data](ioType: T) extends MultiIOModule {
+class PassthroughModule[T <: Data](ioType: T) extends Module {
   val in = IO(Input(ioType))
   val out = IO(Output(ioType))
   out := in
 }
 
-class PassthroughQueue[T <: Data](ioType: T) extends MultiIOModule {
+class PassthroughQueue[T <: Data](ioType: T) extends Module {
   val in = IO(Flipped(Decoupled(ioType)))
   val out = IO(Decoupled(ioType))
   out <> in
 }
 
-class ShifterModule[T <: Data](ioType: T, cycles: Int = 1) extends MultiIOModule {
+class ShifterModule[T <: Data](ioType: T, cycles: Int = 1) extends Module {
   val in = IO(Input(ioType))
   val out = IO(Output(ioType))
   out := ShiftRegister(in, cycles)
 }
 
-class QueueModule[T <: Data](ioType: T, entries: Int) extends MultiIOModule {
+class QueueModule[T <: Data](ioType: T, entries: Int) extends Module {
   val in = IO(Flipped(Decoupled(ioType)))
   val out = IO(Decoupled(ioType))
   out <> Queue(in, entries)

--- a/src/test/scala/chiseltest/tests/ValidQueueTest.scala
+++ b/src/test/scala/chiseltest/tests/ValidQueueTest.scala
@@ -11,7 +11,7 @@ import org.scalatest._
 import treadle.VerboseAnnotation
 import org.scalatest.flatspec.AnyFlatSpec
 
-class ValidQueueModule(typeGen: Data, val delay: Int) extends MultiIOModule {
+class ValidQueueModule(typeGen: Data, val delay: Int) extends Module {
   val in = IO(Flipped(Valid(typeGen)))
   val out = IO(Valid(typeGen))
 
@@ -72,7 +72,7 @@ class ValidQueueTest extends AnyFlatSpec with ChiselScalatestTester {
     val c = Bool()
   }
 
-  class TriQueueModule(typeGen: Data, delay: Int) extends MultiIOModule {
+  class TriQueueModule(typeGen: Data, delay: Int) extends Module {
     val in0  = IO(Flipped(Valid(typeGen)))
     val out0 = IO(Valid(typeGen))
     out0 := Pipe(in0, delay)

--- a/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
+++ b/src/test/scala/chiseltest/tests/VecPokeExpectTest.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chiseltest._
 import org.scalatest.freespec.AnyFreeSpec
 
-class UsesVec extends MultiIOModule {
+class UsesVec extends Module {
   val in   = IO(Input(Vec(4, UInt(5.W))))
   val addr = IO(Input(UInt(8.W)))
   val out  = IO(Output(UInt(5.W)))


### PR DESCRIPTION
This leaves us with a single deprecation warning when compiling `chiseltest`.