### PR TITLE
build: match chisel3 behavior by only building for scala 2.12.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .settings
 .idea
 *.iml
+/*.bsp/
 
 /test_run_dir/
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,39 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq("-Xsource:2.11")
-    }
-  }
-}
-
-def javacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // Scala 2.12 requires Java 8. We continue to generate
-    //  Java 7 compatible code for Scala 2.11
-    //  for compatibility with old clients.
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
-        Seq("-source", "1.7", "-target", "1.7")
-      case _ =>
-        Seq("-source", "1.8", "-target", "1.8")
-    }
-  }
-}
-
 organization := "edu.berkeley.cs"
 name := "chiseltest"
 
 version := "0.5-SNAPSHOT"
 
-scalaVersion := "2.12.10"
+scalaVersion := "2.12.13"
 
-crossScalaVersions := Seq("2.12.10", "2.11.12")
+crossScalaVersions := Seq("2.12.13")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
@@ -93,7 +67,8 @@ val defaultVersions = Seq(
 libraryDependencies ++= defaultVersions.map { case (dep, ver) =>
   "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", ver) }
 
-scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
+
 scalacOptions ++= Seq("-deprecation", "-feature", "-language:reflectiveCalls")
 
-javacOptions ++= javacOptionsVersion(scalaVersion.value)
+// Scala 2.12 requires Java 8.
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,7 @@ import mill.scalalib._
 import mill.scalalib.scalafmt._
 import mill.scalalib.publish._
 
-object chiseltest extends mill.Cross[chiseltestCrossModule]("2.11.12", "2.12.10")
+object chiseltest extends mill.Cross[chiseltestCrossModule]("2.12.13")
 
 val defaultVersions = Map(
   "chisel3" -> "3.5-SNAPSHOT",
@@ -37,26 +37,16 @@ class chiseltestCrossModule(val crossScalaVersion: String) extends CrossSbtModul
 
   def publishVersion = "0.5-SNAPSHOT"
 
-  private def javacCrossOptions = majorVersion match {
-    case i if i < 12 => Seq("-source", "1.7", "-target", "1.7")
-    case _ => Seq("-source", "1.8", "-target", "1.8")
-  }
-
-  private def scalacCrossOptions = majorVersion match {
-    case i if i < 12 => Seq()
-    case _ => Seq("-Xsource:2.11")
-  }
-
   override def scalacOptions = T {
     super.scalacOptions() ++ Seq(
       "-deprecation",
       "-feature",
       "-language:reflectiveCalls" // required by SemanticDB compiler plugin
-    ) ++ scalacCrossOptions
+    )
   }
 
   override def javacOptions = T {
-    super.javacOptions() ++ javacCrossOptions
+    super.javacOptions() ++ Seq("-source", "1.8", "-target", "1.8")
   }
 
   override def moduleDeps = super.moduleDeps ++ chisel3Module ++ treadleModule


### PR DESCRIPTION
Since Chisel 3.5 recently dropped Scala 2.11 support, there is no point in keeping it in chiseltest.