### PR TITLE
Add binary reuse to Verilator tests via annotation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ libraryDependencies ++= Seq(
   "edu.berkeley.cs" %% "treadle"       % defaultVersions("treadle"),
   "org.scalatest"   %% "scalatest"     % "3.2.8",
   "com.lihaoyi"     %% "utest"         % "0.7.9",
+  "org.json4s" %% "json4s-jackson" % "3.6.11",
   "org.scala-lang"   % "scala-reflect" % scalaVersion.value,
   compilerPlugin("edu.berkeley.cs" % "chisel3-plugin"    % defaultVersions("chisel3") cross CrossVersion.full)
 ) ++ {

--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -107,6 +107,16 @@ case object UserCoverageAnnotation extends TestOptionObject {
   )
 }
 
+case object CachingAnnotation extends TestOptionObject {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "t-use-caching",
+      toAnnotationSeq = _ => Seq(CachingAnnotation),
+      helpText = "caches built simulations when using Verilator"
+    )
+  )
+}
+
 trait BackendAnnotation extends TestOptionObject {
   self: Object =>
   def executive: BackendExecutive

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -1,16 +1,24 @@
 package chiseltest.legacy.backends.verilator
 
-import java.io.{File, FileWriter}
+import java.io.{BufferedReader, File, FileReader, FileWriter}
 
 import chiseltest.backends.BackendExecutive
 import chiseltest.internal._
 import chisel3.{assert, Module}
 import chisel3.experimental.DataMirror
+import chisel3.internal.firrtl.Circuit
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselStage}
-import firrtl.annotations.ReferenceTarget
+import firrtl.annotations.{JsonProtocol, ReferenceTarget}
+import firrtl.ir.StructuralHash
 import firrtl.stage.RunFirrtlTransformAnnotation
 import firrtl.transforms.CombinationalPath
 import firrtl.util.BackendCompilationUtilities
+import java.security.MessageDigest
+import javax.xml.bind.DatatypeConverter
+
+import org.json4s._
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.Serialization.{read, write}
 
 object VerilatorExecutive extends BackendExecutive {
   import firrtl._
@@ -27,6 +35,147 @@ object VerilatorExecutive extends BackendExecutive {
       case "clock" => "clock"
       case _ =>
         s"${component.module}.${component.name}"
+    }
+  }
+
+  def getCachedSim[T <: Module](
+    dut:            T,
+    circuit:        Circuit,
+    elaboratedAnno: AnnotationSeq,
+    targetDir:      String
+  ): Option[BackendInstance[T]] = {
+    if (elaboratedAnno.contains(CachingAnnotation)) {
+      val highFirrtlAnnos = (new ChiselStage).run(
+        elaboratedAnno :+ RunFirrtlTransformAnnotation(new HighFirrtlEmitter)
+      )
+
+      val rawFirrtl = highFirrtlAnnos.collect { case EmittedFirrtlCircuitAnnotation(e) => e.value }
+        .map(l => firrtl.Parser.parse(l))
+        .head
+
+      val sortedModuleHashStrings = new firrtl.stage.transforms.Compiler(targets = firrtl.stage.Forms.HighForm)
+        .transform(firrtl.CircuitState(rawFirrtl, Seq()))
+        .circuit
+        .modules
+        .map(m => m.name -> StructuralHash.sha256WithSignificantPortNames(m))
+        .sortBy(_._1)
+        .map(_._2.hashCode().toString) // TODO: Replace .hashCode().toString with .str
+
+      val sortedModuleMessageDigest = MessageDigest
+        .getInstance("SHA-256")
+        .digest(
+          sortedModuleHashStrings
+            .toString()
+            .getBytes("UTF-8")
+        )
+
+      val moduleHashHex = DatatypeConverter
+        .printHexBinary(sortedModuleMessageDigest)
+
+      val moduleHashFile = new File(targetDir, "module.hash")
+
+      val oldModuleHashHex = if (moduleHashFile.exists()) {
+        new BufferedReader(new FileReader(moduleHashFile)).readLine()
+      } else {
+        " "
+      }
+
+      val moduleWriter = new FileWriter(moduleHashFile)
+      moduleWriter.write(moduleHashHex)
+      moduleWriter.close()
+
+      // Hash the deterministic elements of elaboratedAnno for comparison, this should
+      // only catch if coverage or vcd flags change
+      val elaboratedAnnoString = elaboratedAnno.toSeq.filter {
+        case _: chisel3.stage.ChiselCircuitAnnotation | _: chisel3.stage.DesignAnnotation[T] |
+            _: firrtl.options.TargetDirAnnotation =>
+          false
+        case _ => true
+      }
+        .map(anno => anno.toString)
+      val firrtlInfoString = Seq(firrtl.BuildInfo.toString)
+      val systemVersionString = Seq(System.getProperty("java.version"), scala.util.Properties.versionNumberString)
+
+      val elaboratedAnnoHashHex = DatatypeConverter
+        .printHexBinary(
+          MessageDigest
+            .getInstance("SHA-256")
+            .digest(
+              (elaboratedAnnoString ++ firrtlInfoString ++ systemVersionString).toString
+                .getBytes("UTF-8")
+            )
+        )
+
+      val annoHashFile = new File(targetDir, "anno.hash")
+
+      val oldElaboratedAnnoHashHex = if (annoHashFile.exists) {
+        new BufferedReader(new FileReader(annoHashFile)).readLine
+      } else {
+        " "
+      }
+
+      val elaboratedAnnoWriter = new FileWriter(annoHashFile)
+      elaboratedAnnoWriter.write(elaboratedAnnoHashHex)
+      elaboratedAnnoWriter.close()
+
+      if (moduleHashHex == oldModuleHashHex && elaboratedAnnoHashHex == oldElaboratedAnnoHashHex) { // Check if we have built a simulator with matching module and annotations
+        val portNames = DataMirror
+          .modulePorts(dut)
+          .flatMap { case (name, data) =>
+            getDataNames(name, data).toList.map {
+              case (p, "reset") => (p, "reset")
+              case (p, "clock") => (p, "clock")
+              case (p, n)       => (p, s"${circuit.name}.$n")
+              //          case (p, n) => (p, s"$n")
+            }
+          }
+          .toMap
+
+        implicit val formats = DefaultFormats
+
+        val pathsJson = new BufferedReader(new FileReader(new File(targetDir, "paths.json"))).readLine()
+        val paths = read[Seq[CombinationalPath]](pathsJson)
+
+        val pathsAsData =
+          combinationalPathsToData(dut, paths, portNames, componentToName)
+
+        val commandJson = new BufferedReader(new FileReader(new File(targetDir, "command.json"))).readLine()
+        val command = read[Seq[String]](commandJson)
+
+        val coverageAnnotations = AnnotationSeq(
+          JsonProtocol.deserialize(new File(targetDir, "coverageAnnotations.json"))
+        )
+
+        return Some(new VerilatorBackend(dut, portNames, pathsAsData, command, targetDir, coverageAnnotations))
+      }
+    }
+    None
+  }
+
+  def cacheSim[T <: Module](
+    paths:               Seq[CombinationalPath],
+    command:             Seq[String],
+    coverageAnnotations: AnnotationSeq,
+    elaboratedAnno:      AnnotationSeq,
+    targetDir:           String
+  ): Unit = {
+    if (elaboratedAnno.contains(CachingAnnotation)) {
+      implicit val formats = DefaultFormats
+
+      // Cache paths as json as they depend on the compiledAnnotations
+      val pathsWriter = new FileWriter(new File(targetDir, "paths.json"))
+      pathsWriter.write(write(paths))
+      pathsWriter.close()
+
+      // Cache command
+      val commandWriter = new FileWriter(new File(targetDir, "command.json"))
+      commandWriter.write(write(command))
+      commandWriter.close()
+
+      // Cache coverage annotations
+      val coverageAnnotationsWriter = new FileWriter(new File(targetDir, "coverageAnnotations.json"))
+      coverageAnnotationsWriter.write(JsonProtocol.serialize(coverageAnnotations.toSeq))
+      coverageAnnotationsWriter.close()
     }
   }
 
@@ -47,6 +196,11 @@ object VerilatorExecutive extends BackendExecutive {
     val elaboratedAnno = (new chisel3.stage.phases.Elaborate).transform(annotationSeq :+ generatorAnnotation)
     val circuit = elaboratedAnno.collect { case x: ChiselCircuitAnnotation => x }.head.circuit
     val dut = getTopModule(circuit).asInstanceOf[T]
+
+    getCachedSim(dut, circuit, elaboratedAnno, targetDir) match {
+      case Some(sim) => return sim
+      case _         =>
+    }
 
     // Create the header files that verilator needs
     CopyVerilatorHeaderFiles(targetDir)
@@ -144,6 +298,8 @@ object VerilatorExecutive extends BackendExecutive {
       combinationalPathsToData(dut, paths, portNames, componentToName)
 
     val coverageAnnotations = VerilatorCoverage.collectCoverageAnnotations(compiledAnnotations)
+
+    cacheSim(paths, command, coverageAnnotations, elaboratedAnno, targetDir)
 
     new VerilatorBackend(dut, portNames, pathsAsData, command, targetDir, coverageAnnotations)
   }

--- a/src/test/scala/chiseltest/experimental/tests/VerilatorCachingTests.scala
+++ b/src/test/scala/chiseltest/experimental/tests/VerilatorCachingTests.scala
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.experimental.tests
+
+import chisel3._
+import chiseltest.tests.{PassthroughModule, StaticModule}
+import chiseltest._
+import chiseltest.experimental.TestOptionBuilder._
+import chiseltest.experimental.sanitizeFileName
+import chiseltest.internal.{CachingAnnotation, VerilatorBackendAnnotation, WriteVcdAnnotation}
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.File
+
+class VerilatorCachingTests extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2 with Verilator and caching"
+
+  val annos = Seq(VerilatorBackendAnnotation, CachingAnnotation)
+
+  it should "test static circuits" in {
+    test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+      c.out.expect(42.U)
+    }
+  }
+
+  it should "fail on poking outputs" in {
+    assertThrows[UnpokeableException] {
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+        c.out.poke(0.U)
+      }
+    }
+  }
+
+  it should "fail on expect mismatch" in {
+    assertThrows[exceptions.TestFailedException] {
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+        c.out.expect(0.U)
+      }
+    }
+  }
+
+  it should "fail with user-defined message" in {
+    intercept[exceptions.TestFailedException] {
+      test(new StaticModule(42.U)).withAnnotations(annos) { c =>
+        c.out.expect(0.U, "user-defined failure message =(")
+      }
+    }.getMessage should include ("user-defined failure message =(")
+  }
+
+  it should "test inputless sequential circuits" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val out = Output(UInt(8.W))
+      })
+      val counter = RegInit(UInt(8.W), 0.U)
+      counter := counter + 1.U
+      io.out := counter
+    }).withAnnotations(annos) { c =>
+      c.io.out.expect(0.U)
+      c.clock.step()
+      c.io.out.expect(1.U)
+      c.clock.step()
+      c.io.out.expect(2.U)
+      c.clock.step()
+      c.io.out.expect(3.U)
+    }
+  }
+
+  it should "test combinational circuits" in {
+    test(new PassthroughModule(UInt(8.W))).withAnnotations(annos) { c =>
+      c.in.poke(0.U)
+      c.out.expect(0.U)
+      c.in.poke(42.U)
+      c.out.expect(42.U)
+    }
+  }
+
+  it should "test sequential circuits" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val in = Input(UInt(8.W))
+        val out = Output(UInt(8.W))
+      })
+      io.out := RegNext(io.in, 0.U)
+    }).withAnnotations(annos) { c =>
+      c.io.in.poke(0.U)
+      c.clock.step()
+      c.io.out.expect(0.U)
+      c.io.in.poke(42.U)
+      c.clock.step()
+      c.io.out.expect(42.U)
+    }
+  }
+
+  it should "test reset" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val in = Input(UInt(8.W))
+        val out = Output(UInt(8.W))
+      })
+      io.out := RegNext(io.in, 0.U)
+    }).withAnnotations(annos) { c =>
+      c.io.out.expect(0.U)
+
+      c.io.in.poke(42.U)
+      c.clock.step()
+      c.io.out.expect(42.U)
+
+      c.reset.poke(true.B)
+      c.io.out.expect(42.U)  // sync reset not effective until next clk
+      c.clock.step()
+      c.io.out.expect(0.U)
+
+      c.clock.step()
+      c.io.out.expect(0.U)
+
+      c.reset.poke(false.B)
+      c.io.in.poke(43.U)
+      c.clock.step()
+      c.io.out.expect(43.U)
+    }
+  }
+
+  it should "write vcd output when passing in a WriteVcdAnnotation" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val a = Input(UInt(8.W))
+        val b = Output(UInt(8.W))
+      })
+      io.b := io.a
+    }).withAnnotations(annos :+ WriteVcdAnnotation) { c =>
+      c.io.a.poke(1.U)
+      c.io.b.expect(1.U)
+      c.clock.step()
+      c.io.a.poke(42.U)
+      c.io.b.expect(42.U)
+    }
+
+    val testDir = new File("test_run_dir" +
+      File.separator +
+      sanitizeFileName(s"Testers2 with Verilator and caching should write vcd output when passing in a WriteVcdAnnotation"))
+
+    val vcdFileOpt = testDir.listFiles.find { f =>
+      f.getPath.endsWith(".vcd")
+    }
+
+    vcdFileOpt.isDefined should be(true)
+    vcdFileOpt.get.delete()
+  }
+
+  it should "handle test being called twice in one case with the same module" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val a = Input(UInt(8.W))
+        val b = Output(UInt(8.W))
+      })
+      io.b := io.a
+    }).withAnnotations(annos) { c =>
+      c.io.a.poke(1.U)
+      c.io.b.expect(1.U)
+      c.clock.step()
+      c.io.a.poke(42.U)
+      c.io.b.expect(42.U)
+    }
+
+    test(new Module {
+      val io = IO(new Bundle {
+        val a = Input(UInt(8.W))
+        val b = Output(UInt(8.W))
+      })
+      io.b := io.a
+    }).withAnnotations(annos) { c =>
+      c.io.a.poke(1.U)
+      c.io.b.expect(1.U)
+      c.clock.step()
+      c.io.a.poke(42.U)
+      c.io.b.expect(42.U)
+    }
+  }
+
+  it should "handle test being called twice in one case with different modules" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val a = Input(UInt(8.W))
+        val b = Output(UInt(8.W))
+      })
+      io.b := io.a
+    }).withAnnotations(annos) { c =>
+      c.io.a.poke(1.U)
+      c.io.b.expect(1.U)
+      c.clock.step()
+      c.io.a.poke(42.U)
+      c.io.b.expect(42.U)
+    }
+
+    test(new Module {
+      val io = IO(new Bundle {
+        val out = Output(UInt(8.W))
+      })
+      val counter = RegInit(UInt(8.W), 0.U)
+      counter := counter + 1.U
+      io.out := counter
+    }).withAnnotations(annos) { c =>
+      c.io.out.expect(0.U)
+      c.clock.step()
+      c.io.out.expect(1.U)
+      c.clock.step()
+      c.io.out.expect(2.U)
+      c.clock.step()
+      c.io.out.expect(3.U)
+    }
+  }
+}


### PR DESCRIPTION
Adds a CachingAnnotation which enables binary reuse across verilator test runs if high FIRRTL, elaborated annotations, and underlying versions match. In testing reduces the VerilatorBasicTests runtime from 35 seconds on first run to 5 seconds on second (cached) run.

Addresses: https://github.com/ucb-bar/chisel-testers2/issues/106 and https://github.com/ucb-bar/chisel-testers2/issues/212