### PR TITLE
ci: install verilator instead of using a container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,18 @@ on:
 jobs:
   test:
     name: sbt test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         scala: [2.12.13]
-    container:
-      image: ucbbar/chisel3-tools
-      options: --user github --entrypoint /bin/bash
-    env:
-      CONTAINER_HOME: /home/github
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Verilator
+        run: |
+          sudo apt-get install -y verilator
+          verilator --version
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
@@ -34,7 +33,7 @@ jobs:
 
   doc:
     name: Documentation and Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -63,7 +62,7 @@ jobs:
   # separate from a Scala versions build matrix to avoid duplicate publishing
   publish:
     needs: [all_tests_passed]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push'
 
     steps:


### PR DESCRIPTION
This gives us a more up to date version of verilator and will make things easier to reproduce for people using the latest Ubuntu LTS.