### PR TITLE
Add Support for using Vec literals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
         uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.8
-      - name: Cache Scala
-        uses: coursier/cache-action@v5
       - name: Test
         run: sbt ++${{ matrix.scala }} test
 
@@ -73,8 +71,6 @@ jobs:
         uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.8
-      - name: Cache Scala
-        uses: coursier/cache-action@v5
       - name: Test
         run: sbt "testOnly chiseltest.backends.verilator.**"
 
@@ -86,8 +82,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
-      - name: Cache
-        uses: coursier/cache-action@v5
       - name: Documentation
         id: doc
         run: sbt doc
@@ -119,8 +113,6 @@ jobs:
         uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.8
-      - name: Cache Scala
-        uses: coursier/cache-action@v5
       - name: Setup GPG (for Publish)
         uses: olafurpg/setup-gpg@v3
       - name: Publish

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -162,7 +162,7 @@ package object chiseltest {
         }
       }
       case (x: Vec[_], value: Vec[_]) => {
-        require(DataMirror.checkTypeEquivalence(x, value), s"Vec[_ type mismatch")
+        require(DataMirror.checkTypeEquivalence(x, value), s"Vec type mismatch")
         (x.getElements.zip(value.getElements)).foreach { case (x, value) =>
           x.poke(value)
         }
@@ -197,7 +197,7 @@ package object chiseltest {
         chiselTypeOf(x).Lit(elementValueFns: _*).asInstanceOf[T]
       }
       case (x: Vec[_]) =>
-        val elementValueFns = x.getElements.zipWithIndex.map { case (elt: Data, index: Int) =>
+        val elementValueFns = x.getElements.map { case elt: Data =>
           elt.peekWithStale(stale)
         }
         Vec.Lit(elementValueFns: _*).asInstanceOf[T]
@@ -234,7 +234,7 @@ package object chiseltest {
         }
       }
       case (x: Vec[_], value: Vec[_]) => {
-        require(DataMirror.checkTypeEquivalence(x, value), s"Vec[_ type mismatch")
+        require(DataMirror.checkTypeEquivalence(x, value), s"Vec type mismatch")
         (x.getElements.zip(value.getElements)).foreach { case (x, value) =>
           x.expectWithStale(value, message, stale)
         }

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -53,7 +53,7 @@ package object chiseltest {
       }.foreach { case (k, v) =>
         v match {
           case record: Record => record.expectPartial(value.elements(k).asInstanceOf[Record])
-          case data: Data => data.expect(value.elements(k))
+          case data:   Data   => data.expect(value.elements(k))
         }
       }
     }
@@ -74,13 +74,13 @@ package object chiseltest {
       x.getElements.zipWithIndex.filter { case (v, index) =>
         DataMirror.directionOf(v) != ActualDirection.Output && {
           value.getElements(index) match {
-            case _: T => true
+            case _:    T    => true
             case data: Data => data.isLit()
           }
         }
       }.foreach { case (v, index) =>
         v match {
-          case vec: T => vec.pokePartial(value.getElements(index).asInstanceOf[T])
+          case vec:  T    => vec.pokePartial(value.getElements(index).asInstanceOf[T])
           case data: Data => data.poke(value.getElements(index))
         }
       }
@@ -93,12 +93,12 @@ package object chiseltest {
       require(DataMirror.checkTypeEquivalence(x, value), s"Vec type mismatch")
       x.getElements.zipWithIndex.filter { case (v, index) =>
         value.getElements(index) match {
-          case _: T => true
+          case _: T    => true
           case d: Data => d.isLit()
         }
       }.foreach { case (v, index) =>
         v match {
-          case vec: T => vec.expectPartial(value.getElements(index).asInstanceOf[T])
+          case vec:  T    => vec.expectPartial(value.getElements(index).asInstanceOf[T])
           case data: Data => data.expect(value.getElements(index))
         }
       }

--- a/src/test/scala/chiseltest/tests/VecLiteralsSpec.scala
+++ b/src/test/scala/chiseltest/tests/VecLiteralsSpec.scala
@@ -3,6 +3,7 @@
 package chiseltest.tests
 
 import chisel3._
+import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 import chisel3.experimental.VecLiterals._
 import chiseltest._
 import org.scalatest._
@@ -64,6 +65,55 @@ class VecLiteralsSpec extends AnyFreeSpec with ChiselScalatestTester with Matche
       c.in.poke(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
       c.in.poke(c.out.peek())
       c.out.expect(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
+    }
+  }
+
+  class FooBar extends Bundle {
+    val foo = UInt(8.W)
+    val bar = UInt(4.W)
+  }
+
+  class BarFoo extends Bundle {
+    val foo = Vec(2, UInt(8.W))
+    val bar = Vec(3, UInt(8.W))
+  }
+
+  "arbitrary nesting of vecs and bundles should be supported" - {
+    "it should round-trip Vec literals" in {
+      val vecOfVec = Vec(2, Vec(2, UInt(8.W)))
+      val vecOfVecLit = vecOfVec.Lit(
+        0 -> vecOfVec(0).Lit(0 -> 0xab.U, 1 -> 0xC.U),
+        1 -> vecOfVec(1).Lit(0 -> 0xde.U, 1 -> 0xf.U)
+      )
+      test(new PassthroughModule(vecOfVec)) { c =>
+        c.in.poke(vecOfVecLit)
+        c.in.poke(c.out.peek())
+        c.out.expect(vecOfVecLit)
+      }
+    }
+    "it should round-trip Vec of Bundle literals" in {
+      val vecOfBundle = Vec(2, new FooBar)
+      val vecOfBundleLit = vecOfBundle.Lit(
+        0 -> (new FooBar).Lit(_.foo -> 0xab.U, _.bar -> 0xc.U),
+        1 -> (new FooBar).Lit(_.foo -> 0xde.U, _.bar -> 0xf.U)
+      )
+      test(new PassthroughModule(vecOfBundle)) { c =>
+        c.in.poke(vecOfBundleLit)
+        c.in.poke(c.out.peek())
+        c.out.expect(vecOfBundleLit)
+      }
+    }
+    "it should round-trip a Bundle of Vec literals" in {
+      val bundleOfVec = new BarFoo
+      val bundleOfVecLit = bundleOfVec.Lit(
+        _.foo -> Vec.Lit(0xaa.U, 0xbb.U),
+        _.bar -> Vec.Lit(0xcc.U, 0xdd.U, 0xee.U)
+      )
+      test(new PassthroughModule(bundleOfVec)) { c =>
+        c.in.poke(bundleOfVecLit)
+        c.in.poke(c.out.peek())
+        c.out.expect(bundleOfVecLit)
+      }
     }
   }
 }

--- a/src/test/scala/chiseltest/tests/VecLiteralsSpec.scala
+++ b/src/test/scala/chiseltest/tests/VecLiteralsSpec.scala
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.tests
+
+import chisel3._
+import chisel3.experimental.VecLiterals._
+import chiseltest._
+import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class VecLiteralsSpec extends AnyFreeSpec with ChiselScalatestTester with Matchers {
+
+  "it should poke Vec literals" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val in = Input(Vec(2, UInt(8.W)))
+
+        val aOut = Output(UInt(8.W))
+        val bOut = Output(UInt(8.W))
+      })
+      io.aOut := io.in(0)
+      io.bOut := io.in(1)
+    }) { c =>
+      c.io.in.poke(chiselTypeOf(c.io.in).Lit(0 -> 0.U, 1 -> 1.U))
+      c.io.aOut.expect(0.U)
+      c.io.bOut.expect(1.U)
+
+      c.io.in.poke(chiselTypeOf(c.io.in).Lit(0 -> 2.U, 1 -> 5.U))
+      c.io.aOut.expect(2.U)
+      c.io.bOut.expect(5.U)
+    }
+  }
+
+  "it should expect Vec literals" in {
+    test(new PassthroughModule(Vec(2, UInt(8.W)))) { c =>
+      c.in.poke(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
+      c.out.expect(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
+      c.in.poke(chiselTypeOf(c.in).Lit(0 -> 2.U, 1 -> 5.U))
+      c.out.expect(chiselTypeOf(c.in).Lit(0 -> 2.U, 1 -> 5.U))
+    }
+  }
+
+  "it should fail on expect mismatch" in {
+    assertThrows[exceptions.TestFailedException] {
+      test(new PassthroughModule(Vec(2, UInt(8.W)))) { c =>
+        c.in.poke(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
+        c.out.expect(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 2.U))
+      }
+    }
+  }
+
+  "it should return a Vec literal when peeking" in {
+    test(new PassthroughModule(Vec(2, UInt(8.W)))) { c =>
+      c.in.poke(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
+      val output = c.out.peek()
+      output(0).litValue should be(0)
+      output(1).litValue should be(1)
+    }
+  }
+
+  "it should roundtrip Vec literals" in {
+    test(new PassthroughModule(Vec(2, UInt(8.W)))) { c =>
+      c.in.poke(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
+      c.in.poke(c.out.peek())
+      c.out.expect(chiselTypeOf(c.in).Lit(0 -> 0.U, 1 -> 1.U))
+    }
+  }
+}


### PR DESCRIPTION
Depends on chipsalliance/chisel3#1834

Extends literal handling API with
- package object chiseltest
  - implicit class testableVec[T <: Vec[_]](x: T)
    - def pokePartial(value: T): Unit
    - def expectPartial(value: T): Unit

Include VecLiteralsSpec for tests