### PR TITLE
Verilator generated artifacts is a subfolder

### DIFF
--- a/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/Utils.scala
@@ -94,9 +94,7 @@ private[chiseltest] object bigIntToStr {
 trait EditableBuildCSimulatorCommand {
   val prefix: String // prefix to be used for error messages
 
-  /**
-    *
-    * @param dir - base target (source) directory
+  /** @param dir - base target (source) directory
     * @return path for generated object files
     */
   def objDir(dir: File): File = dir
@@ -418,9 +416,9 @@ private[chiseltest] object verilogToVerilator extends EditableBuildCSimulatorCom
     )
 
     val staleObjDri = objDir(dir)
-    if(staleObjDri.exists()) {
+    if (staleObjDri.exists()) {
       println(s"Deleting stale Verilator object directory: $staleObjDri")
-      if(!firrtl.FileUtils.deleteDirectoryHierarchy(staleObjDri)){
+      if (!firrtl.FileUtils.deleteDirectoryHierarchy(staleObjDri)) {
         throw BackendException(s"Deleting $staleObjDri failed!")
       }
     }

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -101,13 +101,13 @@ object VerilatorExecutive extends BackendExecutive {
     val verilatorCFlags = moreVerilatorCFlags ++ coverageFlag
 
     val verilateRetCode = verilogToVerilator(
-        circuit.name,
-        targetDirFile,
-        cppHarnessFile,
-        moreVerilatorFlags = verilatorFlags,
-        moreVerilatorCFlags = verilatorCFlags,
-        editCommands = commandEditsFile
-      ).!
+      circuit.name,
+      targetDirFile,
+      cppHarnessFile,
+      moreVerilatorFlags = verilatorFlags,
+      moreVerilatorCFlags = verilatorCFlags,
+      editCommands = commandEditsFile
+    ).!
 
     assert(
       verilateRetCode == 0,

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -100,31 +100,35 @@ object VerilatorExecutive extends BackendExecutive {
     val verilatorFlags = moreVerilatorFlags ++ writeVcdFlag ++ coverageFlags
     val verilatorCFlags = moreVerilatorCFlags ++ coverageFlag
 
-    assert(
-      verilogToVerilator(
+    val verilateRetCode = verilogToVerilator(
         circuit.name,
-        new File(targetDir),
+        targetDirFile,
         cppHarnessFile,
         moreVerilatorFlags = verilatorFlags,
         moreVerilatorCFlags = verilatorCFlags,
         editCommands = commandEditsFile
-      ).! == 0,
+      ).!
+
+    assert(
+      verilateRetCode == 0,
       s"verilator command failed on circuit ${circuit.name} in work dir $targetDir"
     )
 
+    val objDir = verilogToVerilator.objDir(targetDirFile)
+
     // patch the coverage cpp provided with verilator
-    PatchCoverageCpp(targetDir)
+    PatchCoverageCpp(objDir.toString())
 
     assert(
-      BackendCompilationUtilities.cppToExe(circuit.name, targetDirFile).! == 0,
-      s"Compilation of verilator generated code failed for circuit ${circuit.name} in work dir $targetDir"
+      BackendCompilationUtilities.cppToExe(circuit.name, objDir).! == 0,
+      s"Compilation of verilator generated code failed for circuit ${circuit.name} in work dir $objDir"
     )
 
     val command = compiledAnnotations
       .collectFirst[Seq[String]] { case TestCommandOverride(f) =>
         f.split(" +")
       }
-      .getOrElse { Seq(new File(targetDir, s"V${circuit.name}").toString) }
+      .getOrElse { Seq(new File(objDir, s"V${circuit.name}").toString) }
 
     val portNames = DataMirror
       .modulePorts(dut)


### PR DESCRIPTION
All binaries, object files, C++ files, Makefiles, etc generated by Verilator are kept in a "verilated" subfolder and deleted before execution of a new test.