### PR TITLE
move verilator caching test to verilator specific directory

### DIFF
--- a/src/test/scala/chiseltest/backends/verilator/VerilatorCachingTests.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorCachingTests.scala
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-package chiseltest.experimental.tests
+package chiseltest.backends.verilator
 
 import chisel3._
-import chiseltest.tests.{PassthroughModule, StaticModule}
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.experimental.sanitizeFileName
 import chiseltest.internal.{CachingAnnotation, VerilatorBackendAnnotation, WriteVcdAnnotation}
+import chiseltest.tests.{PassthroughModule, StaticModule}
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
This ensures that it will be included in the verilator regression tests that run on all supported versions.