### PR TITLE
Fix comparison of hashes for `CachingAnnotation`

### DIFF
--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -97,7 +97,8 @@ object VerilatorExecutive extends BackendExecutive {
 
       val annoHashFile = targetDirPath / "anno.hash"
 
-      val annoHashMatches = Try(os.read.bytes(annoHashFile)).toOption.filter(_.sameElements(elaboratedAnnoHash)).nonEmpty
+      val annoHashMatches =
+        Try(os.read.bytes(annoHashFile)).toOption.filter(_.sameElements(elaboratedAnnoHash)).nonEmpty
 
       os.write.over(annoHashFile, elaboratedAnnoHash)
 

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -71,7 +71,7 @@ object VerilatorExecutive extends BackendExecutive {
       val moduleHashFile = targetDirPath / "module.hash"
 
       val moduleHashMatches =
-        Try(os.read.bytes(moduleHashFile)).toOption.filter(_.equals(sortedModuleMessageDigest)).nonEmpty
+        Try(os.read.bytes(moduleHashFile)).toOption.filter(_.sameElements(sortedModuleMessageDigest)).nonEmpty
 
       os.write.over(moduleHashFile, sortedModuleMessageDigest)
 
@@ -97,7 +97,7 @@ object VerilatorExecutive extends BackendExecutive {
 
       val annoHashFile = targetDirPath / "anno.hash"
 
-      val annoHashMatches = Try(os.read.bytes(annoHashFile)).toOption.filter(_.equals(elaboratedAnnoHash)).nonEmpty
+      val annoHashMatches = Try(os.read.bytes(annoHashFile)).toOption.filter(_.sameElements(elaboratedAnnoHash)).nonEmpty
 
       os.write.over(annoHashFile, elaboratedAnnoHash)
 


### PR DESCRIPTION
I had made a stupid mistake in #308 and used `equals` for comparing hashes, which is object comparison not the content, and will always fail on two separate arrays, even if their contents are the same. The original code in #267 also used `==` which I believe is an alias for `equals`, and therefore never worked either.
That probably why I never got `CachingAnnotation` to work :)
It seems there are currently no tests checking for effectiveness of `CachingAnnotation`, or if they are they don't seem to be working.