### PR TITLE
remove testOnly, since upstream implemented it.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -74,12 +74,6 @@ class chiseltestCrossModule(val crossScalaVersion: String) extends CrossSbtModul
         "utest.runner.Framework"
       )
     }
-
-    // a sbt-like testOnly command.
-    // for example, mill -i "chiseltest[2.12.12].test.testOnly" "chiseltest.tests.AsyncClockTest"
-    def testOnly(args: String*) = T.command {
-      super.runMain("org.scalatest.run", args: _*)
-    }
   }
 
   def pomSettings = T {


### PR DESCRIPTION
Mill implemented its own `testOnly` in https://github.com/com-lihaoyi/mill/commit/838e3259921718778b01b554455bbf1942865cb5 , this PR fixed compile in mill 0.9.8.