### PR TITLE
remove simulator specific Verilog coverage flags

### DIFF
--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -47,66 +47,6 @@ case object WriteVcdAnnotation extends TestOptionObject {
   )
 }
 
-case object LineCoverageAnnotation extends TestOptionObject {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[Unit](
-      longOption = "t-line-coverage",
-      toAnnotationSeq = _ => Seq(LineCoverageAnnotation),
-      helpText = "adds line coverage in VCS or Verilator"
-    )
-  )
-}
-
-case object ToggleCoverageAnnotation extends TestOptionObject {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[Unit](
-      longOption = "t-toggle-coverage",
-      toAnnotationSeq = _ => Seq(ToggleCoverageAnnotation),
-      helpText = "adds toggle coverage in VCS or Verilator"
-    )
-  )
-}
-
-case object BranchCoverageAnnotation extends TestOptionObject {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[Unit](
-      longOption = "t-branch-coverage",
-      toAnnotationSeq = _ => Seq(ToggleCoverageAnnotation),
-      helpText = "adds branch coverage in VCS"
-    )
-  )
-}
-
-case object ConditionalCoverageAnnotation extends TestOptionObject {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[Unit](
-      longOption = "t-conditional-coverage",
-      toAnnotationSeq = _ => Seq(ToggleCoverageAnnotation),
-      helpText = "adds conditional coverage in VCS"
-    )
-  )
-}
-
-case object StructuralCoverageAnnotation extends TestOptionObject {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[Unit](
-      longOption = "t-structural-coverage",
-      toAnnotationSeq = _ => Seq(LineCoverageAnnotation),
-      helpText = "adds all forms of structural in VCS or Verilator"
-    )
-  )
-}
-
-case object UserCoverageAnnotation extends TestOptionObject {
-  val options: Seq[ShellOption[_]] = Seq(
-    new ShellOption[Unit](
-      longOption = "t-user-coverage",
-      toAnnotationSeq = _ => Seq(LineCoverageAnnotation),
-      helpText = "adds user coverage in VCS or Verilator"
-    )
-  )
-}
-
 case object CachingAnnotation extends TestOptionObject {
   val options: Seq[ShellOption[_]] = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsAnnotations.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsAnnotations.scala
@@ -22,11 +22,17 @@ case object SuppressVcsVcd extends VcsOptionObject {
   )
 }
 
-/** A sequence string flags to add to verilator command line
+/** A sequence string flags to add to vcs command line
   *
   * @param flags additional flags
   */
 case class VcsFlags(flags: Seq[String]) extends VcsOption
+
+/** A sequence string flags to add to the VCS created simulation binary
+  *
+  * @param flags additional flags
+  */
+case class VcsSimFlags(flags: Seq[String]) extends VcsOption
 
 /** CLI builder for VcsFlags
   */

--- a/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
+++ b/src/main/scala/chiseltest/legacy/backends/vcs/VcsBackend.scala
@@ -21,4 +21,12 @@ class VcsBackend[T <: Module](
   command:             Seq[String],
   targetDir:           String,
   coverageAnnotations: AnnotationSeq)
-    extends VerilatorBackend(dut, dataNames, combinationalPaths, command, targetDir, coverageAnnotations, supportsCoverage = false)
+    extends VerilatorBackend(
+      dut,
+      dataNames,
+      combinationalPaths,
+      command,
+      targetDir,
+      coverageAnnotations,
+      supportsCoverage = false
+    )

--- a/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
+++ b/src/main/scala/chiseltest/legacy/backends/verilator/VerilatorExecutive.scala
@@ -203,28 +203,11 @@ object VerilatorExecutive extends BackendExecutive {
       .getOrElse(Seq.empty)
     val writeVcdFlag = if (compiledAnnotations.contains(WriteVcdAnnotation)) { Seq("--trace") }
     else { Seq() }
-    val coverageFlags = Seq((compiledAnnotations.collect {
-      case LineCoverageAnnotation   => List("--coverage-line")
-      case ToggleCoverageAnnotation => List("--coverage-toggle")
-      // user coverage is enabled by default
-      //case UserCoverageAnnotation       => List("--coverage-user")
-      case StructuralCoverageAnnotation => List("--coverage-line", "--coverage-toggle")
-    } :+ List("--coverage-user")).flatten.distinct.mkString(" "))
-
     val commandEditsFile = compiledAnnotations.collectFirst { case CommandEditsFile(f) => f }
       .getOrElse("")
 
-    val coverageFlag =
-      if (
-        compiledAnnotations
-          .intersect(Seq(LineCoverageAnnotation, ToggleCoverageAnnotation, UserCoverageAnnotation))
-          .nonEmpty
-      ) {
-        Seq("-DSP_COVERAGE_ENABLE")
-      } else { Seq() }
-
-    val verilatorFlags = moreVerilatorFlags ++ writeVcdFlag ++ coverageFlags
-    val verilatorCFlags = moreVerilatorCFlags ++ coverageFlag
+    val verilatorFlags = moreVerilatorFlags ++ writeVcdFlag ++ List("--coverage-user")
+    val verilatorCFlags = moreVerilatorCFlags
 
     val verilateRetCode = verilogToVerilator(
       circuit.name,

--- a/src/test/scala/chiseltest/backends/verilator/VerilatorCachingTests.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorCachingTests.scala
@@ -17,7 +17,7 @@ class VerilatorCachingTests extends AnyFlatSpec with ChiselScalatestTester with 
   val default = Seq(VerilatorBackendAnnotation)
   val withCaching = Seq(VerilatorBackendAnnotation, CachingAnnotation)
   private val cachingMin = 0.7    // at least 70% difference between first (uncached) and subsequent runs (cached)
-  private val nonCachingMax = 0.2 // max 20% difference between runs
+  private val nonCachingMax = 0.4 // max 40% difference between runs
 
   private def runTest(num: Int, annos: AnnotationSeq): Long = {
     time(test(new StaticModule(num.U)).withAnnotations(annos) { c =>


### PR DESCRIPTION
If the user wants to rely on the simulator built-in Verilog coverage, they can directly supply the relevant flags to the simulator.

I talked to @vighneshiyer and he is OK removing this as it isn't a very clean API.

I improved the Verilator tests to actually check that an appropriate coverage file is generated.