### PR TITLE
build: remove JSON and XML dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,6 @@ libraryDependencies ++= Seq(
   "edu.berkeley.cs" %% "treadle"       % defaultVersions("treadle"),
   "org.scalatest"   %% "scalatest"     % "3.2.9",
   "com.lihaoyi"     %% "utest"         % "0.7.9",
-  "org.json4s" %% "json4s-jackson" % "3.6.11",
   "org.scala-lang"   % "scala-reflect" % scalaVersion.value,
   compilerPlugin("edu.berkeley.cs" % "chisel3-plugin"    % defaultVersions("chisel3") cross CrossVersion.full)
 ) ++ {

--- a/build.sc
+++ b/build.sc
@@ -55,8 +55,6 @@ class chiseltestCrossModule(val crossScalaVersion: String) extends CrossSbtModul
     Agg(
       ivy"org.scalatest::scalatest:3.2.0",
       ivy"com.lihaoyi::utest:0.7.9",
-      ivy"org.json4s::json4s-jackson:3.6.11",
-      ivy"javax.xml.bind:jaxb-api:2.3.1",
     ) ++ chisel3IvyDeps ++ treadleIvyDeps
   }
 


### PR DESCRIPTION
It is easier to import the JSON serialization through
our firrtl dependency instead of managing the version
ourselves.