### PR TITLE
Minimal Formal Verification Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           java-version: ${{ matrix.jvm }}
       - name: Test
-        run: sbt ++${{ matrix.scala }} "testOnly -- -l RequiresVcs -l RequiresVerilator"
+        run: sbt ++${{ matrix.scala }} "testOnly -- -l RequiresVcs -l RequiresVerilator -l Formal"
 
   verilator-mac:
     name: verilator regression on mac
@@ -103,6 +103,36 @@ jobs:
       - name: Test
         run: sbt "testOnly chiseltest.backends.verilator.** ; testOnly -- -n RequiresVerilator"
 
+  formal:
+    name: formal verification tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Z3 and CVC4 for Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y z3 cvc4
+          z3 --version
+          cvc4 --version
+      - name: Install Z3 and CVC4 for MacOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install z3
+          brew tap cvc4/cvc4
+          brew install cvc4/cvc4/cvc4
+          z3 --version
+          cvc4 --version
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Test
+        run: sbt "testOnly -- -n Formal"
+
   doc:
     name: Documentation and Formatting
     runs-on: ubuntu-20.04
@@ -123,7 +153,7 @@ jobs:
   # When adding new jobs, please add them to `needs` below
   all_tests_passed:
     name: "all tests passed"
-    needs: [test, doc, verilator, verilator-mac]
+    needs: [test, doc, verilator, verilator-mac, formal]
     runs-on: ubuntu-latest
     steps:
       - run: echo Success!

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "edu.berkeley.cs" %% "chisel3"       % defaultVersions("chisel3"),
   "edu.berkeley.cs" %% "treadle"       % defaultVersions("treadle"),
+  "edu.berkeley.cs" %% "maltese-smt"   % "0.5-SNAPSHOT",
   "org.scalatest"   %% "scalatest"     % "3.1.4",
   "com.lihaoyi"     %% "utest"         % "0.7.9",
   "net.java.dev.jna" % "jna" % "5.8.0",

--- a/build.sc
+++ b/build.sc
@@ -56,6 +56,7 @@ class chiseltestCrossModule(val crossScalaVersion: String) extends CrossSbtModul
       ivy"org.scalatest::scalatest:3.2.0",
       ivy"com.lihaoyi::utest:0.7.9",
       ivy"net.java.dev.jna:jna:5.8.0",
+      ivy"edu.berkeley.cs::maltese-smt:0.5-SNAPSHOT",
     ) ++ chisel3IvyDeps ++ treadleIvyDeps
   }
 

--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -5,13 +5,19 @@ package chiseltest
 import chiseltest.internal._
 import chiseltest.experimental.{sanitizeFileName, ChiselTestShell}
 import chisel3.Module
+import chiseltest.internal.TestEnvInterface.addDefaultTargetDir
 import firrtl.AnnotationSeq
 import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
 
 import scala.util.DynamicVariable
 
-trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvInterface { this: TestSuite =>
+trait HasTestName { def getTestName: String }
+
+trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvInterface with HasTestName {
+  this: TestSuite =>
+
+  override def getTestName: String = sanitizeFileName(scalaTestContext.value.get.name)
 
   class TestBuilder[T <: Module](
     val dutGen:        () => T,

--- a/src/main/scala/chiseltest/ChiselUtestTester.scala
+++ b/src/main/scala/chiseltest/ChiselUtestTester.scala
@@ -6,6 +6,7 @@ import chiseltest.internal._
 import chiseltest.experimental.sanitizeFileName
 import utest.TestSuite
 import chisel3.Module
+import chiseltest.internal.TestEnvInterface.addDefaultTargetDir
 import firrtl.AnnotationSeq
 import utest.framework.Formatter
 

--- a/src/main/scala/chiseltest/RawTester.scala
+++ b/src/main/scala/chiseltest/RawTester.scala
@@ -5,7 +5,7 @@ package chiseltest
 import chiseltest.internal._
 import chiseltest.experimental.sanitizeFileName
 import chisel3.Module
-
+import chiseltest.internal.TestEnvInterface.addDefaultTargetDir
 import firrtl.AnnotationSeq
 
 /** Used to run simple tests that do not require a scalatest environment in order to run

--- a/src/main/scala/chiseltest/formal/AddResetAssumptionPass.scala
+++ b/src/main/scala/chiseltest/formal/AddResetAssumptionPass.scala
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal
+
+import chisel3.util.log2Ceil
+import firrtl._
+import firrtl.annotations._
+import firrtl.options.Dependency
+import firrtl.transforms._
+
+/** adds an assumption to the toplevel module that all resets are active in the first cycle */
+private object AddResetAssumptionPass extends Transform with DependencyAPIMigration {
+  // run on lowered firrtl
+  override def prerequisites = Seq(
+    Dependency(firrtl.passes.ExpandWhens),
+    Dependency(firrtl.passes.LowerTypes),
+    Dependency(firrtl.transforms.RemoveReset),
+    // try to work around dead code elimination removing our registers
+    Dependency[firrtl.transforms.DeadCodeElimination]
+  )
+  override def invalidates(a: Transform) = false
+  // since we generate PresetRegAnnotations, we need to run after preset propagation
+  override def optionalPrerequisites = Seq(Dependency[PropagatePresetAnnotations])
+  // we want to run before the actual Verilog is emitted
+  override def optionalPrerequisiteOf = firrtl.stage.Forms.BackendEmitters
+
+  override def execute(state: CircuitState): CircuitState = {
+    val resetLength = getResetLength(state.annotations)
+    if (resetLength == 0 || resetIsPreset(state.circuit.main, state.annotations)) return state
+
+    val main = state.circuit.modules.collectFirst { case m: ir.Module if m.name == state.circuit.main => m }.get
+    val (clock, reset) = findClockAndReset(main)
+    val namespace = Namespace(main)
+
+    // add a port for the preset init
+    val preset = ir.Port(ir.NoInfo, namespace.newName("_preset"), ir.Input, ir.AsyncResetType)
+    val presetAnno = PresetAnnotation(CircuitTarget(main.name).module(main.name).ref(preset.name))
+
+    // add reset count register
+    val resetCountType = ir.UIntType(ir.IntWidth(List(1, log2Ceil(resetLength + 1)).max))
+    val resetCount = ir.DefRegister(
+      ir.NoInfo,
+      namespace.newName("_resetCount"),
+      resetCountType,
+      clock,
+      reset = ir.Reference(preset).copy(flow = SourceFlow),
+      init = Utils.getGroundZero(resetCountType)
+    )
+    val resetCountSource = ir.Reference(resetCount).copy(flow = SourceFlow)
+
+    // we are in the reset phase iff the counter is less than the reset length
+    val lessThanCycles = ir.DoPrim(
+      PrimOps.Lt,
+      List(resetCountSource, ir.UIntLiteral(resetLength, resetCountType.width)),
+      List(),
+      Utils.BoolType
+    )
+    val resetPhase = ir.DefNode(ir.NoInfo, namespace.newName("_resetPhase"), lessThanCycles)
+    val resetPhaseRef = ir.Reference(resetPhase).copy(flow = SourceFlow)
+
+    // we increment the counter as long as we are in the reset phase, after that it just retains its value
+    val nextValue = Utils.mux(resetPhaseRef, plusOne(resetCountSource), resetCountSource)
+    val nextCon = ir.Connect(ir.NoInfo, ir.Reference(resetCount).copy(flow = SinkFlow), nextValue)
+
+    // add assumption that reset is active
+    val resetActive = ir.Verification(
+      ir.Formal.Assume,
+      ir.NoInfo,
+      clock,
+      pred = reset,
+      en = resetPhaseRef,
+      msg = ir.StringLit(""),
+      name = namespace.newName("_resetActive")
+    )
+
+    // collect all our statements and add them to the main module
+    val stmts = Seq(resetCount, resetPhase, nextCon, resetActive)
+    val instrumented = main.copy(ports = main.ports :+ preset, body = ir.Block(main.body +: stmts))
+
+    // substitute instrumented main and add annotations
+    val otherMods = state.circuit.modules.filterNot(_.name == state.circuit.main)
+    state.copy(
+      circuit = state.circuit.copy(modules = instrumented +: otherMods),
+      annotations = presetAnno +: state.annotations
+    )
+  }
+
+  def getResetLength(annos: AnnotationSeq): Int = {
+    annos.collect { case ResetOption(n) => n }.distinct.toList match {
+      case List()    => 1 // default
+      case List(one) => one
+      case more =>
+        throw new RuntimeException(s"Received multiple disagreeing reset options! " + more.mkString(", "))
+    }
+  }
+
+  private def resetIsPreset(main: String, annos: AnnotationSeq): Boolean = {
+    annos.collectFirst {
+      case PresetAnnotation(target) if target.circuit == main && target.module == main && target.ref == "reset" => true
+    }.getOrElse(false)
+  }
+
+  private def findClockAndReset(m: ir.Module): (ir.Reference, ir.Reference) = {
+    val clock = m.ports
+      .find(_.name == "clock")
+      .getOrElse(
+        throw new RuntimeException(s"[${m.name}] Expected module to have a port named clock!")
+      )
+    val reset = m.ports
+      .find(_.name == "reset")
+      .getOrElse(
+        throw new RuntimeException(s"[${m.name}] Expected module to have a port named reset!")
+      )
+    (ir.Reference(clock).copy(flow = SourceFlow), ir.Reference(reset).copy(flow = SourceFlow))
+  }
+
+  private def plusOne(e: ir.Expression): ir.Expression = {
+    val width = e.tpe.asInstanceOf[ir.UIntType].width.asInstanceOf[ir.IntWidth].width
+    val addTpe = ir.UIntType(ir.IntWidth(width + 1))
+    val add = ir.DoPrim(PrimOps.Add, List(e, ir.UIntLiteral(1, ir.IntWidth(width))), List(), addTpe)
+    ir.DoPrim(PrimOps.Bits, List(add), List(width - 1, 0), e.tpe)
+  }
+}

--- a/src/main/scala/chiseltest/formal/Formal.scala
+++ b/src/main/scala/chiseltest/formal/Formal.scala
@@ -3,12 +3,12 @@
 package chiseltest.formal
 
 import chisel3.Module
-import chiseltest.ChiselScalatestTester
-import chiseltest.experimental.sanitizeFileName
-import chiseltest.formal.backends.{FormalEngineAnnotation, Z3EngineAnnotation}
+import chiseltest.HasTestName
+import chiseltest.formal.backends.FormalEngineAnnotation
+import chiseltest.internal.TestEnvInterface
 import chiseltest.simulator.{Compiler, WriteVcdAnnotation}
 import firrtl.{AnnotationSeq, CircuitState}
-import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.annotations.NoTargetAnnotation
 import firrtl.transforms.formal.DontAssertSubmoduleAssumptionsAnnotation
 
 sealed trait FormalOp extends NoTargetAnnotation
@@ -28,12 +28,11 @@ private[chiseltest] object FailedBoundedCheckException {
 }
 
 /** Adds the `verify` command for formal checks to a ChiselScalatestTester */
-trait Formal { this: ChiselScalatestTester =>
+trait Formal { this: HasTestName =>
   def verify[T <: Module](dutGen: => T, annos: AnnotationSeq): Unit = {
-    val withTargetDir = addDefaultTargetDir(getTestName, annos)
+    val withTargetDir = TestEnvInterface.addDefaultTargetDir(getTestName, annos)
     Formal.verify(dutGen, withTargetDir)
   }
-  private def getTestName: String = sanitizeFileName(scalaTestContext.value.get.name)
 }
 
 private object Formal {

--- a/src/main/scala/chiseltest/formal/Formal.scala
+++ b/src/main/scala/chiseltest/formal/Formal.scala
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal
+
+import chisel3.Module
+import chiseltest.ChiselScalatestTester
+import chiseltest.experimental.sanitizeFileName
+import chiseltest.formal.backends.{FormalEngineAnnotation, Z3EngineAnnotation}
+import chiseltest.simulator.{Compiler, WriteVcdAnnotation}
+import firrtl.{AnnotationSeq, CircuitState}
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.transforms.formal.DontAssertSubmoduleAssumptionsAnnotation
+
+sealed trait FormalOp extends NoTargetAnnotation
+case class BoundedCheck(kMax: Int = -1) extends FormalOp
+
+/** Specifies how many cycles the circuit should be reset for. */
+case class ResetOption(cycles: Int = 1) extends NoTargetAnnotation {
+  require(cycles >= 0, "The number of cycles must not be negative!")
+}
+
+class FailedBoundedCheckException(val message: String, val failAt: Int) extends Exception(message)
+private[chiseltest] object FailedBoundedCheckException {
+  def apply(module: String, failAt: Int): FailedBoundedCheckException = {
+    val msg = s"[$module] found an assertion violation $failAt steps after reset!"
+    new FailedBoundedCheckException(msg, failAt)
+  }
+}
+
+/** Adds the `verify` command for formal checks to a ChiselScalatestTester */
+trait Formal { this: ChiselScalatestTester =>
+  def verify[T <: Module](dutGen: => T, annos: AnnotationSeq): Unit = {
+    val withTargetDir = addDefaultTargetDir(getTestName, annos)
+    Formal.verify(dutGen, withTargetDir)
+  }
+  private def getTestName: String = sanitizeFileName(scalaTestContext.value.get.name)
+}
+
+private object Formal {
+  def verify[T <: Module](dutGen: => T, annos: AnnotationSeq): Unit = {
+    val ops = getOps(annos)
+    assert(ops.nonEmpty, "No verification operation was specified!")
+    val withDefaults = addDefaults(annos)
+
+    // elaborate the design and compile to low firrtl
+    val (highFirrtl, _) = Compiler.elaborate(() => dutGen, withDefaults)
+    val lowFirrtl = Compiler.toLowFirrtl(highFirrtl, Seq(DontAssertSubmoduleAssumptionsAnnotation))
+
+    // add reset assumptions
+    val withReset = AddResetAssumptionPass.execute(lowFirrtl)
+
+    // execute operations
+    val resetLength = AddResetAssumptionPass.getResetLength(withDefaults)
+    ops.foreach(executeOp(withReset, resetLength, _))
+  }
+
+  val DefaultEngine: FormalEngineAnnotation = Z3EngineAnnotation
+  def addDefaults(annos: AnnotationSeq): AnnotationSeq = {
+    Seq(addDefaultEngine(_), addWriteVcd(_)).foldLeft(annos)((old, f) => f(old))
+  }
+  def addDefaultEngine(annos: AnnotationSeq): AnnotationSeq = {
+    if (annos.exists(_.isInstanceOf[FormalEngineAnnotation])) { annos }
+    else { DefaultEngine +: annos }
+  }
+  def addWriteVcd(annos: AnnotationSeq): AnnotationSeq = {
+    if (annos.contains(WriteVcdAnnotation)) { annos }
+    else { WriteVcdAnnotation +: annos }
+  }
+  def getOps(annos: AnnotationSeq): Seq[FormalOp] = {
+    annos.collect { case a: FormalOp => a }.distinct
+  }
+  def executeOp(state: CircuitState, resetLength: Int, op: FormalOp): Unit = op match {
+    case BoundedCheck(kMax) =>
+      backends.Maltese.bmc(state.circuit, state.annotations, kMax = kMax, resetLength = resetLength)
+  }
+}

--- a/src/main/scala/chiseltest/formal/backends/FlattenPass.scala
+++ b/src/main/scala/chiseltest/formal/backends/FlattenPass.scala
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal.backends
+
+import firrtl.analyses.InstanceKeyGraph
+import firrtl.analyses.InstanceKeyGraph.InstanceKey
+import firrtl.annotations._
+import firrtl.options.Dependency
+import firrtl.passes.InlineAnnotation
+import firrtl.stage.Forms
+import firrtl._
+
+private case class DoNotInlineAnnotation(target: ModuleTarget) extends SingleTargetAnnotation[ModuleTarget] {
+  override def duplicate(n: ModuleTarget) = copy(target = n)
+}
+
+/** Allows us to track the names of state elements through the inlining process */
+private case class StateAnnotation(target: ReferenceTarget, pathName: String, dataBits: Int, depth: Int)
+    extends SingleTargetAnnotation[ReferenceTarget] {
+  override def duplicate(n: ReferenceTarget): StateAnnotation = copy(target = n)
+}
+
+private object StateAnnotation {
+  def apply(target: ReferenceTarget, tpe: ir.Type, depth: BigInt = -1): StateAnnotation = {
+    new StateAnnotation(target, toPathName(target), firrtl.bitWidth(tpe).toInt, depth.toInt)
+  }
+
+  private def toPathName(t: Target): String = {
+    t.tokens.flatMap {
+      case TargetToken.Ref(r)      => Some(r)
+      case TargetToken.Instance(i) => Some(i)
+      case TargetToken.Field(f)    => Some(f)
+      case _: TargetToken.OfModule => None
+    }.mkString(".")
+  }
+}
+
+/** Annotates the complete hierarchy to be flattened. */
+private object FlattenPass extends Transform with DependencyAPIMigration {
+  override def prerequisites = Forms.LowForm
+  // this pass relies on modules not being dedupped yet (TODO: review that assumption!)
+  override def optionalPrerequisiteOf = Seq(
+    Dependency[firrtl.passes.InlineInstances] // this pass generates annotations for the InlineInstances pass!
+  )
+
+  override def optionalPrerequisites = Seq(
+    // we want to trace the renaming of the registers created my the mem delay pass
+    Dependency(firrtl.passes.memlib.VerilogMemDelays)
+  )
+  override def invalidates(a: Transform): Boolean = false
+
+  override protected def execute(state: firrtl.CircuitState): firrtl.CircuitState = {
+    val doNotInline = state.annotations.collect {
+      case DoNotInlineAnnotation(target) if target.circuit == state.circuit.main => target.module
+    }
+    val iGraph = InstanceKeyGraph(state.circuit)
+    val children = iGraph.getChildInstances.toMap
+
+    // we tag every module to be inlined unless it is explicitly marked as doNotInline
+    val cRef = CircuitTarget(state.circuit.main)
+    val main = cRef.module(state.circuit.main)
+    val inlineAnnos = inlines(main, main)(children, doNotInline.toSet, iGraph.moduleMap)
+
+    val annos = state.annotations.filterNot(_.isInstanceOf[DoNotInlineAnnotation]) ++ inlineAnnos
+    state.copy(annotations = annos)
+  }
+
+  private def inlines(
+    relTarget: ModuleTarget,
+    absTarget: IsModule
+  )(
+    implicit children: Map[String, Seq[InstanceKey]],
+    doNotInline:       Set[String],
+    getModule:         String => ir.DefModule
+  ): AnnotationSeq = {
+    if (doNotInline.contains(relTarget.module)) { Seq() }
+    else {
+      val stateAnnos = findStates(absTarget, getModule(relTarget.module))
+      val childAnnos = children(relTarget.module).flatMap(c =>
+        inlines(relTarget.targetParent.module(c.module), absTarget.instOf(c.name, c.module))
+      )
+      if (relTarget.circuit == relTarget.module) { // never inline the main module
+        stateAnnos ++: childAnnos
+      } else {
+        InlineAnnotation(toName(relTarget)) +: stateAnnos ++: childAnnos
+      }
+    }
+  }
+
+  private def findStates(m: IsModule, dm: ir.DefModule): Seq[StateAnnotation] = dm match {
+    case mod: ir.Module => findStates(m, mod.body)
+    case _ => List()
+  }
+
+  private def findStates(m: IsModule, s: ir.Statement): Seq[StateAnnotation] = s match {
+    case reg: ir.DefRegister   => List(StateAnnotation(m.ref(reg.name), reg.tpe))
+    case mem: ir.DefMemory     => List(StateAnnotation(m.ref(mem.name), mem.dataType, mem.depth))
+    case b:   ir.Block         => b.stmts.flatMap(findStates(m, _))
+    case _:   ir.Conditionally => throw new RuntimeException("Not low form!")
+    case _ => List()
+  }
+
+  /** the InlineInstances pass uses Name instead of Target */
+  private def toName(m: ModuleTarget): ModuleName = ModuleName(m.module, CircuitName(m.circuit))
+
+  def getStateMap(main: String, annos: AnnotationSeq): Map[String, String] = {
+    annos.collect {
+      case StateAnnotation(target, pathName, _, _) if target.circuit == main && target.module == main =>
+        target.ref -> pathName
+    }.toMap
+  }
+  def getMemoryDepths(main: String, annos: AnnotationSeq): Map[String, Int] = {
+    annos.collect {
+      case StateAnnotation(target, pathName, _, depth)
+          if target.circuit == main && target.module == main && depth > 0 =>
+        pathName -> depth
+    }.toMap
+  }
+}

--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal.backends
+
+import chiseltest.formal.FailedBoundedCheckException
+import firrtl._
+import firrtl.annotations._
+import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlStage, RunFirrtlTransformAnnotation}
+import maltese.mc._
+import maltese.smt.solvers._
+import maltese.smt
+import chiseltest.simulator.{Compiler, WriteVcdAnnotation}
+import firrtl.options.Dependency
+
+sealed trait FormalEngineAnnotation extends NoTargetAnnotation
+
+/** Use a SMTLib based model checker with the CVC4 SMT solver.
+  * @note CVC4 often performs better than Z3.
+  */
+case object CVC4EngineAnnotation extends FormalEngineAnnotation
+
+/** Use a SMTLib based model checker with the Z3 SMT solver.
+  * @note Z3 is the most widely available and easiest to install SMT solver.
+  */
+case object Z3EngineAnnotation extends FormalEngineAnnotation
+
+/** Uses the btormc model checker from the boolector code base.
+  * @note btormc is generally faster than Z3 or CVC4 but needs to be built from source
+  */
+private case object BtormcEngineAnnotation extends FormalEngineAnnotation
+
+/** Formal Verification based on the firrtl compiler's SMT backend and the maltese SMT libraries solver bindings. */
+private[chiseltest] object Maltese {
+  def bmc(circuit: ir.Circuit, annos: AnnotationSeq, kMax: Int, resetLength: Int = 0): Unit = {
+    require(kMax > 0)
+    require(resetLength >= 0)
+    val targetDir = Compiler.requireTargetDir(annos)
+    val sysInfo = toTransitionSystem(circuit, annos)
+    val checkers = makeCheckers(annos)
+    assert(checkers.size == 1, "Parallel checking not supported atm!")
+    checkers.head.check(sysInfo.sys, kMax = (kMax + resetLength)) match {
+      case ModelCheckFail(witness) =>
+        val writeVcd = annos.contains(WriteVcdAnnotation)
+        if (writeVcd) {
+          val sim = new TransitionSystemSimulator(sysInfo.sys)
+          sim.run(witness, vcdFileName = Some((targetDir / s"${circuit.main}.bmc.vcd").toString))
+          val trace = witnessToTrace(sysInfo, witness)
+          Trace.replayOnTreadle(trace, circuit, annos)
+        }
+        val failSteps = witness.inputs.length - 1 - resetLength
+        throw FailedBoundedCheckException(circuit.main, failSteps)
+      case ModelCheckSuccess() => // good!
+    }
+  }
+
+  private val LoweringAnnos: AnnotationSeq = Seq(
+    // we need to flatten the whole circuit
+    RunFirrtlTransformAnnotation(Dependency(FlattenPass)),
+    RunFirrtlTransformAnnotation(Dependency[firrtl.passes.InlineInstances])
+  )
+
+  private case class SysInfo(sys: TransitionSystem, stateMap: Map[String, String], memDepths: Map[String, Int])
+
+  private def toTransitionSystem(circuit: ir.Circuit, annos: AnnotationSeq): SysInfo = {
+    val logLevel = Seq() // Seq("-ll", "info")
+    val res = firrtlStage.execute(
+      Array("--start-from", "low", "-E", "smt2") ++ logLevel,
+      FirrtlCircuitAnnotation(circuit) +: annos ++: LoweringAnnos
+    )
+    val stateMap = FlattenPass.getStateMap(circuit.main, res)
+    val memDepths = FlattenPass.getMemoryDepths(circuit.main, res)
+    val sys = firrtl.backends.experimental.smt.ExpressionConverter.toMaltese(res).get
+
+    // print the system, convenient for debugging, might disable once we have done more testing
+    if (true) {
+      val targetDir = Compiler.requireTargetDir(annos)
+      os.write.over(targetDir / s"${circuit.main}.sys", sys.serialize)
+    }
+
+    SysInfo(sys, stateMap, memDepths)
+  }
+
+  private def firrtlStage = new FirrtlStage
+
+  private def makeCheckers(annos: AnnotationSeq): Seq[IsModelChecker] = {
+    val engines = annos.collect { case a: FormalEngineAnnotation => a }
+    assert(engines.nonEmpty, "You need to provide at least one formal engine annotation!")
+    engines.map {
+      case CVC4EngineAnnotation   => new SMTModelChecker(new CVC4SMTLib)
+      case Z3EngineAnnotation     => new SMTModelChecker(new Z3SMTLib)
+      case BtormcEngineAnnotation => new BtormcModelChecker
+    }
+  }
+
+  private def expandMemWrites(depth: Int, values: Seq[(Option[BigInt], BigInt)]): Seq[BigInt] = {
+    var mem = Vector.fill(depth)(BigInt(0))
+    values.foreach {
+      case (None, value) =>
+        mem = Vector.fill(depth)(value)
+      case (Some(addr), value) =>
+        mem = mem.updated(addr.toInt, value)
+    }
+    mem
+  }
+
+  private def witnessToTrace(sysInfo: SysInfo, w: Witness): Trace = {
+    val inputNames = sysInfo.sys.inputs.map(_.name).toIndexedSeq
+    val stateNames = sysInfo.sys.states.map(_.name).map(sysInfo.stateMap).toIndexedSeq
+
+    Trace(
+      inputs = w.inputs.map(_.toSeq.map { case (i, value) => inputNames(i) -> value }),
+      regInit = w.regInit.toSeq.map { case (i, value) => stateNames(i) -> value },
+      memInit = w.memInit.toSeq.map { case (i, values) =>
+        val name = stateNames(i)
+        name -> expandMemWrites(sysInfo.memDepths(name), values)
+      }
+    )
+  }
+
+}

--- a/src/main/scala/chiseltest/formal/backends/Trace.scala
+++ b/src/main/scala/chiseltest/formal/backends/Trace.scala
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal.backends
+
+import chiseltest.simulator.{Compiler, TreadleBackendAnnotation}
+import firrtl._
+
+/** Represents the inputs and starting state needed to re-create an execution trace. */
+private case class Trace(
+  inputs:  Seq[Seq[(String, BigInt)]],
+  regInit: Seq[(String, BigInt)],
+  memInit: Seq[(String, Seq[BigInt])])
+
+private object Trace {
+  def replayOnTreadle(trace: Trace, circuit: ir.Circuit, annos: AnnotationSeq): Unit = {
+    val dut = TreadleBackendAnnotation.getSimulator.createContext(CircuitState(circuit, annos))
+
+    // initialize
+    trace.regInit.foreach { case (name, value) => dut.poke(name, value) }
+    trace.memInit.foreach { case (name, values) =>
+      values.zipWithIndex.foreach { case (value, addr) =>
+        dut.pokeMemory(name, addr, value)
+      }
+    }
+
+    // run
+    trace.inputs.foreach { inputs =>
+      inputs.foreach { case (name, value) => dut.poke(name, value) }
+      dut.step()
+    }
+
+    dut.finish()
+
+    // TODO: check that the right assertion was hit!
+  }
+}

--- a/src/main/scala/chiseltest/formal/package.scala
+++ b/src/main/scala/chiseltest/formal/package.scala
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest
+
+package object formal {
+  // expose public flags
+  val CVC4EngineAnnotation = backends.CVC4EngineAnnotation
+  val Z3EngineAnnotation = backends.Z3EngineAnnotation
+}

--- a/src/main/scala/chiseltest/internal/TestEnvInterface.scala
+++ b/src/main/scala/chiseltest/internal/TestEnvInterface.scala
@@ -18,22 +18,6 @@ trait TestEnvInterface {
 
   def topFileName: Option[String]
 
-  /** Will add a TargetDirAnnotation with defaultDir with "test_run_dir" path prefix to the annotations
-    * if there is not a TargetDirAnnotation already present
-    *
-    * @param defaultDir     a default directory
-    * @param annotationSeq  annotations to add it to, unless one is already there
-    * @return
-    */
-  def addDefaultTargetDir(defaultDir: String, annotationSeq: AnnotationSeq): AnnotationSeq = {
-    if (annotationSeq.exists { x => x.isInstanceOf[TargetDirAnnotation] }) {
-      annotationSeq
-    } else {
-      val target = TargetDirAnnotation("test_run_dir" + File.separator + defaultDir)
-      AnnotationSeq(annotationSeq ++ Seq(target))
-    }
-  }
-
   /** Logs a tester failure at this point.
     * Failures queued until the next checkpoint.
     */
@@ -113,6 +97,25 @@ trait TestEnvInterface {
     // TODO: report multiple exceptions simultaneously
     for (failure <- batchedFailures) {
       throw failure
+    }
+  }
+}
+
+private[chiseltest] object TestEnvInterface {
+
+  /** Will add a TargetDirAnnotation with defaultDir with "test_run_dir" path prefix to the annotations
+    * if there is not a TargetDirAnnotation already present
+    *
+    * @param defaultDir     a default directory
+    * @param annotationSeq  annotations to add it to, unless one is already there
+    * @return
+    */
+  def addDefaultTargetDir(defaultDir: String, annotationSeq: AnnotationSeq): AnnotationSeq = {
+    if (annotationSeq.exists { x => x.isInstanceOf[TargetDirAnnotation] }) {
+      annotationSeq
+    } else {
+      val target = TargetDirAnnotation("test_run_dir" + File.separator + defaultDir)
+      AnnotationSeq(annotationSeq ++ Seq(target))
     }
   }
 }

--- a/src/main/scala/chiseltest/simulator/Compiler.scala
+++ b/src/main/scala/chiseltest/simulator/Compiler.scala
@@ -32,9 +32,9 @@ private[chiseltest] object Compiler {
 
     (state, dut.asInstanceOf[M])
   }
-  def toLowFirrtl(state: firrtl.CircuitState): firrtl.CircuitState = {
+  def toLowFirrtl(state: firrtl.CircuitState, annos: AnnotationSeq = List()): firrtl.CircuitState = {
     requireTargetDir(state.annotations)
-    val inAnnos = stateToAnnos(state)
+    val inAnnos = annos ++: stateToAnnos(state)
     val res = firrtlStage.execute(Array("-E", "low"), inAnnos)
     annosToState(res)
   }

--- a/src/test/scala/chiseltest/formal/BasicBoundedCheckTests.scala
+++ b/src/test/scala/chiseltest/formal/BasicBoundedCheckTests.scala
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal
+
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.verification
+
+class BasicBoundedCheckTests extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  behavior of "verify command"
+
+  it should "support simple bmc with a passing check" taggedAs FormalTag in {
+    // this one should pass since we only check one step
+    verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 1)))
+  }
+
+  it should "support simple bmc with a failing check" taggedAs FormalTag in {
+    // this one will fail
+    assertThrows[FailedBoundedCheckException] {
+      verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 2)))
+    }
+  }
+
+  it should "support assumption" taggedAs FormalTag in {
+    verify(new AssumeAssertTestModule, Seq(BoundedCheck(kMax = 1)))
+  }
+
+  it should "support assumption in nested modules" taggedAs FormalTag in {
+    verify(new NestedAssertAssumeTestModule, Seq(BoundedCheck(kMax = 1)))
+  }
+
+  it should "detect a failure in DanielModuleWithBadAssertion" taggedAs FormalTag in {
+    assertThrows[FailedBoundedCheckException] {
+      verify(new DanielModuleWithBadAssertion, Seq(BoundedCheck(kMax = 4)))
+    }
+  }
+
+  it should "verify DanielModuleWithGoodAssertion" taggedAs FormalTag in {
+    verify(new DanielModuleWithGoodAssertion, Seq(BoundedCheck(kMax = 4)))
+  }
+}
+
+class AssumeAssertTestModule extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+  out := in + 1.U
+  verification.assume(in > 12.U && in < 255.U)
+  verification.assert(out > 13.U)
+}
+
+class NestedAssertAssumeTestModule extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+  val child = Module(new AssumeAssertTestModule)
+  child.in := in
+  out := child.out
+}
+
+// from Daniel Kasza's dank-formal library
+class DanielModuleWithBadAssertion extends Module {
+  val io = IO(new Bundle {
+    val in = Input(Bool())
+    val a = Output(Bool())
+    val b = Output(Bool())
+  })
+
+  val aReg = RegInit(true.B)
+  val bReg = RegInit(false.B)
+  io.a := aReg
+  io.b := bReg
+
+  when (io.in) {
+    aReg := true.B
+    bReg := false.B
+  }.otherwise {
+    aReg := false.B
+    bReg := true.B
+  }
+
+  verification.assert(aReg && bReg)
+}
+
+// from Daniel Kasza's dank-formal library
+class DanielModuleWithGoodAssertion extends Module {
+  val io = IO(new Bundle {
+    val in = Input(Bool())
+    val a = Output(Bool())
+    val b = Output(Bool())
+  })
+
+  val aReg = RegInit(true.B)
+  val bReg = RegInit(false.B)
+  io.a := aReg
+  io.b := bReg
+
+  when (io.in) {
+    aReg := true.B
+    bReg := false.B
+  }.otherwise {
+    aReg := false.B
+    bReg := true.B
+  }
+
+  verification.assert(aReg ^ bReg)
+}

--- a/src/test/scala/chiseltest/formal/FormalTag.scala
+++ b/src/test/scala/chiseltest/formal/FormalTag.scala
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal
+
+import org.scalatest.Tag
+
+/** To disable tests that require formal tools (Z3, CVC4, btormc ...) use the following: `sbt testOnly -- -l Formal` */
+object FormalTag extends Tag("Formal")

--- a/src/test/scala/chiseltest/formal/MemoryTests.scala
+++ b/src/test/scala/chiseltest/formal/MemoryTests.scala
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal
+
+import chisel3.SyncReadMem.ReadUnderWrite
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.verification
+import firrtl.ir.ReadUnderWrite
+
+// most of the tests are inspired by the MemorySpec in firrtl.backends.experimental.smt.end2end
+class MemoryTests extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "Registered read-first memory" should "return written data after two cycles" taggedAs FormalTag in {
+    verify(new ReadFirstMemoryReturnsDataAfterTwoCycles, Seq(BoundedCheck(3)))
+  }
+  "Registered read-first memory" should "not return written data after one cycle" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new ReadFirstMemoryReturnsDataAfterOneCycle, Seq(BoundedCheck(3)))
+    }
+    assert(e.failAt == 1)
+  }
+}
+
+class SyncMemTestModule(readUnderWrite: ReadUnderWrite) extends Module {
+  val writeAddr = IO(Input(UInt(5.W)))
+  val readAddr = IO(Input(UInt(5.W)))
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+
+  val m = SyncReadMem(32, UInt(8.W), readUnderWrite)
+  m.write(writeAddr, in)
+  val readValue = m.read(readAddr, true.B)
+  out := readValue
+
+  val cycle = RegInit(0.U(8.W))
+  cycle := Mux(cycle === 100.U, 100.U, cycle + 1.U)
+}
+
+class ReadFirstMemoryReturnsDataAfterTwoCycles extends SyncMemTestModule(ReadUnderWrite.Old) {
+  val pastWriteAddr = RegNext(writeAddr)
+  when(cycle >= 1.U) {
+    // we assume the we read from the address that we last wrote to
+    verification.assume(readAddr === pastWriteAddr)
+  }
+  val pastPastIn = RegNext(RegNext(in))
+  when(cycle >= 2.U) {
+    verification.assert(out === pastPastIn)
+  }
+}
+
+class ReadFirstMemoryReturnsDataAfterOneCycle extends SyncMemTestModule(ReadUnderWrite.Old) {
+  verification.assume(readAddr === writeAddr)
+  val pastIn = RegNext(in)
+  when(cycle >= 1.U) {
+    verification.assert(out === pastIn)
+  }
+}

--- a/src/test/scala/chiseltest/formal/ResetAssumptionTests.scala
+++ b/src/test/scala/chiseltest/formal/ResetAssumptionTests.scala
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal
+
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.{ChiselAnnotation, annotate, verification}
+import firrtl.annotations.PresetAnnotation
+
+// very similar to the firrtl example in the backend tests, but in this case we rely on the fact
+// that the high level interface is going to ensure that the design is reset for a single cycle!
+class FailAfterModule(n: Int) extends Module {
+  val counter = RegInit(0.U(log2Ceil(n + 1).W))
+  counter := counter + 1.U
+  verification.assert(counter < n.U)
+}
+
+// in order to make sure that our reset assumptions pass respects preset annotated resets
+class FailAfterPresetModule(n: Int) extends Module with RequireAsyncReset {
+  annotate(new ChiselAnnotation {
+    override def toFirrtl = PresetAnnotation(reset.toTarget)
+  })
+  val counter = RegInit(0.U(log2Ceil(n + 1).W))
+  counter := counter + 1.U
+  withReset(false.B) {
+    verification.assert(counter < n.U)
+  }
+}
+
+// this module has a counter that always starts at zero at the beginning of the formal
+// test and thus we can count how many cycles reset lasts
+class ResetCountCheckModule(resetCycles: Int) extends Module {
+  require(resetCycles > 0)
+  val preset = IO(Input(AsyncReset()))
+  annotate(new ChiselAnnotation {
+    override def toFirrtl = PresetAnnotation(preset.toTarget)
+  })
+
+  // saturating counter
+  val resetCount = withReset(preset) { RegInit(0.U(8.W)) }
+  resetCount := Mux(resetCount === 255.U, 255.U, resetCount + 1.U)
+  // we should always **at least** reset for `resetCycles` cycles
+  verification.assert(resetCount >= resetCycles.U)
+}
+
+class ResetAssumptionTests extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  behavior of "AddResetAssumptionPass"
+
+  it should "not add any reset assumptions with ResetOption(0)" taggedAs FormalTag in {
+    // this would normally pass, but since we removed the reset assumption it does not!
+    assertThrows[FailedBoundedCheckException] {
+      verify(new FailAfterModule(15), Seq(BoundedCheck(kMax = 2), ResetOption(cycles = 0)))
+    }
+  }
+
+  it should "always check for k steps after reset " taggedAs FormalTag in {
+    Seq(1,2,3,4).foreach { ii =>
+      assertThrows[FailedBoundedCheckException] {
+        verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 2), ResetOption(cycles = ii)))
+      }
+    }
+  }
+
+  it should "reset for the right amount of cycles" taggedAs FormalTag in {
+    Seq(1,2,3,4).foreach { ii =>
+      verify(new ResetCountCheckModule(ii), Seq(BoundedCheck(kMax = 2), ResetOption(cycles = ii)))
+    }
+  }
+
+  it should "ignore the reset if it is preset annotated" taggedAs FormalTag in {
+    // this should pass since we reset for one cycle and the module only fails after 4
+    verify(new FailAfterPresetModule(4), Seq(BoundedCheck(kMax = 2), ResetOption(cycles = 1)))
+    verify(new FailAfterPresetModule(4), Seq(BoundedCheck(kMax = 1), ResetOption(cycles = 2)))
+
+    // this should fail since the module always fails after 4 cycles, no matter the reset!
+    assertThrows[FailedBoundedCheckException] {
+      verify(new FailAfterPresetModule(4), Seq(BoundedCheck(kMax = 3), ResetOption(cycles = 1)))
+    }
+    assertThrows[FailedBoundedCheckException] {
+      verify(new FailAfterPresetModule(4), Seq(BoundedCheck(kMax = 2), ResetOption(cycles = 2)))
+    }
+  }
+}

--- a/src/test/scala/chiseltest/formal/backends/FirrtlBmcTests.scala
+++ b/src/test/scala/chiseltest/formal/backends/FirrtlBmcTests.scala
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal.backends
+
+import chiseltest.formal.{FailedBoundedCheckException, FormalTag}
+import firrtl.annotations._
+import chiseltest.utils.FlatSpecWithTargetDir
+import chiseltest.simulator.{Compiler, WriteVcdAnnotation}
+import firrtl._
+
+class FirrtlBmcTests extends FlatSpecWithTargetDir {
+  behavior of "maltese bmc"
+
+  private val mRef = CircuitTarget("test").module("test")
+
+  private def failAfter(n: Int): String =
+    s"""circuit test:
+       |  module test:
+       |    input clock : Clock
+       |    input reset : AsyncReset
+       |
+       |    reg count : UInt<32>, clock with : (reset => (reset, UInt(0)))
+       |    count <= add(count, UInt(1))
+       |    assert(clock, lt(count, UInt($n)), UInt(1), "") : leq_assert
+       |""".stripMargin
+
+  private val PresetAnno = PresetAnnotation(mRef.ref("reset"))
+
+  private def loadFirrtl(src: String, annos: AnnotationSeq): CircuitState = {
+    val state = CircuitState(firrtl.Parser.parse(src), annos)
+    Compiler.toLowFirrtl(state)
+  }
+  private def loadFirrtl(src: String): CircuitState =
+    loadFirrtl(src, withTargetDir(Seq(PresetAnno)))
+
+  private val CVC4 = CVC4EngineAnnotation
+  private val VCD = WriteVcdAnnotation
+
+  it should "succeed for a limited amount of cycles" taggedAs FormalTag in {
+    val state = loadFirrtl(failAfter(2))
+    Maltese.bmc(state.circuit, CVC4 +: state.annotations, kMax = 1)
+  }
+
+  it should "fail after the appropriate amount of cycles" taggedAs FormalTag in {
+    Seq(1,2,3,10,20,100).foreach { ii =>
+      val state = loadFirrtl(failAfter(ii))
+
+      val e = intercept[FailedBoundedCheckException] {
+        Maltese.bmc(state.circuit, VCD +: CVC4 +: state.annotations, kMax = 101)
+      }
+      assert(e.failAt == ii)
+    }
+  }
+
+  private def nestedSrc(n: Int): String =
+    s"""circuit test:
+       |  module child:
+       |    input clock : Clock
+       |    input reset : AsyncReset
+       |    output count : UInt<32>
+       |    reg count_reg : UInt<32>, clock with : (reset => (reset, UInt(0)))
+       |    count_reg <= add(count_reg, UInt(1))
+       |    count <= count_reg
+       |
+       |  module test:
+       |    input clock : Clock
+       |    input reset : AsyncReset
+       |
+       |    inst c of child
+       |    c.clock <= clock
+       |    c.reset <= reset
+       |
+       |    assert(clock, lt(c.count, UInt($n)), UInt(1), "") : leq_assert
+       |""".stripMargin
+
+  it should "work on a circuit with a submodule" taggedAs FormalTag in {
+    val state = loadFirrtl(nestedSrc(5))
+
+    // this should not fail
+    Maltese.bmc(state.circuit, CVC4 +: state.annotations, kMax = 4)
+
+    // this should fail
+    val e = intercept[FailedBoundedCheckException] {
+      Maltese.bmc(state.circuit, CVC4 +: state.annotations, kMax = 6)
+    }
+    assert(e.failAt == 5)
+
+    // this should fail and produce a VCD
+    val vcdFile = targetDir / "test.vcd"
+    if(os.exists(vcdFile)) { os.remove(vcdFile) }
+    assertThrows[FailedBoundedCheckException] {
+      Maltese.bmc(state.circuit, VCD +: CVC4 +: state.annotations, kMax = 6)
+    }
+    assert(os.exists(vcdFile))
+  }
+}

--- a/src/test/scala/chiseltest/simulator/ComplianceTest.scala
+++ b/src/test/scala/chiseltest/simulator/ComplianceTest.scala
@@ -3,8 +3,7 @@
 package chiseltest.simulator
 
 import chiseltest.utils.FlatSpecWithTargetDir
-import firrtl.{AnnotationSeq, CircuitState}
-import firrtl.options.TargetDirAnnotation
+import firrtl._
 import org.scalatest.Tag
 
 /** Base class for all simulator compliance tests. */
@@ -17,15 +16,8 @@ abstract class ComplianceTest(sim: Simulator, protected val tag: Tag) extends Fl
   }
 
   def load(src: String, annos: AnnotationSeq = List()): SimulatorContext = {
-    val withTargetDir: AnnotationSeq =
-      if (annos.exists(_.isInstanceOf[TargetDirAnnotation])) {
-        annos
-      } else {
-        targetDirAnno +: annos
-      }
-    sim.createContext(loadFirrtl(src, withTargetDir))
+    sim.createContext(loadFirrtl(src, withTargetDir(annos)))
   }
-
 }
 
 // a hack for when we do not actually want to tag the tests

--- a/src/test/scala/chiseltest/utils/FlatSpecWithTargetDir.scala
+++ b/src/test/scala/chiseltest/utils/FlatSpecWithTargetDir.scala
@@ -3,6 +3,7 @@
 package chiseltest.utils
 
 import chiseltest.experimental.sanitizeFileName
+import firrtl.AnnotationSeq
 import firrtl.options.TargetDirAnnotation
 import org.scalatest.{Outcome, Tag}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -26,6 +27,10 @@ abstract class FlatSpecWithTargetDir extends AnyFlatSpec {
 
   protected def targetDirAnno = TargetDirAnnotation("test_run_dir/" + getTestName)
   protected def targetDir = os.pwd / os.RelPath(targetDirAnno.directory)
+  protected def withTargetDir(annos: AnnotationSeq): AnnotationSeq = {
+    if (annos.exists(_.isInstanceOf[TargetDirAnnotation])) { annos
+    } else { targetDirAnno +: annos }
+  }
 
 
   def getTestName: String = {


### PR DESCRIPTION
This PR adds some fundamental formal verification support.

A user needs to:
1) add `with Formal` to their `ChiselScalatestTester` derived testing class
2) call `verify` with a verification operation

So for a simple bounded check the syntax is:
```.scala
verify(new Dut, Seq(BoundedCheck(kMax = 1)))
```

Public Annotations included in this PR:
- `Z3EngineAnnotation`: use Z3 for model checking (default)
- `CVC4EngineAnnotation`: use CVC4 for model checking
- `BoundedCheck`: the only verification op so far, but could be extended with something like `KInduction`
- `ResetOption`: by default the formal backend will drive the reset pin high for at least one cycle in the beginning of the check; `ResetOption(0)` will remove any constraints from the reset pin, `ResetOption(3)` will enforce a reset period of at least three cycles

When the check fails, the counter example is automatically replayed with treadle, thus the generated VCD should have the same quality as if it was generated from a unit test.

Things that are missing from this MVP:
- support for more conservative modelling of undefined behaviors
- support for stop statements as assertions
- proofs (using k-induction or other backend specific techniques)
- library support for `past`
- coverage support