### PR TITLE
simulator: add minimal peek/poke support for memories

### DIFF
--- a/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
@@ -75,9 +75,11 @@ private class TreadleContext(tester: TreadleTester, toplevel: TopmoduleInfo) ext
     }
   }
 
-  override def peek(signal: String): BigInt = tester.peek(signal)
-
-  override def poke(signal: String, value: BigInt): Unit = tester.poke(signal, value)
+  override def peek(signal:       String): BigInt = tester.peek(signal)
+  override def peekMemory(signal: String, index: Long) = tester.peekMemory(signal, index.toInt)
+  override def poke(signal:       String, value: BigInt): Unit = tester.poke(signal, value)
+  override def pokeMemory(signal: String, index: Long, value: BigInt): Unit =
+    tester.pokeMemory(signal, index.toInt, value)
 
   override def finish(): Unit = tester.finish
 


### PR DESCRIPTION
Only supported in treadle for now!

This feature is needed for the `iotesters` compatibility PR as well as for the formal verification PR.