### PR TITLE
Single threaded by default

### DIFF
--- a/src/main/scala/chiseltest/internal/BackendExecutive.scala
+++ b/src/main/scala/chiseltest/internal/BackendExecutive.scala
@@ -13,7 +13,7 @@ import firrtl.transforms.{CheckCombLoops, CombinationalPath}
 
 object BackendExecutive {
 
-  def start[T <: Module](dutGen: () => T, testersAnnotationSeq: AnnotationSeq): GenericBackend[T] = {
+  def start[T <: Module](dutGen: () => T, testersAnnotationSeq: AnnotationSeq): BackendInstance[T] = {
 
     // elaborate the design
     val (highFirrtl, dut: T) = Compiler.elaborate[T](dutGen, testersAnnotationSeq)
@@ -36,7 +36,12 @@ object BackendExecutive {
     val sim = Simulator.getSimulator(testersAnnotationSeq)
     val tester = sim.createContext(lowFirrtl)
 
-    new GenericBackend(dut, portNames, pathsAsData, tester, coverageAnnotations)
+    val useThreads = testersAnnotationSeq.contains(UseThreads)
+    if (useThreads) {
+      new GenericBackend(dut, portNames, pathsAsData, tester, coverageAnnotations)
+    } else {
+      new SingleThreadBackend(dut, portNames, pathsAsData, tester, coverageAnnotations)
+    }
   }
 
   private def componentToName(component: ReferenceTarget): String = component.name

--- a/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
+++ b/src/main/scala/chiseltest/internal/SingleThreadBackend.scala
@@ -1,0 +1,126 @@
+package chiseltest.internal
+
+import chisel3.{Clock, Data, Module}
+import chiseltest.{ClockResolutionException, Region}
+import chiseltest.coverage.TestCoverage
+import chiseltest.simulator.SimulatorContext
+import firrtl.AnnotationSeq
+
+/** Chiseltest backend that does not support fork or timescope but is generally faster since it
+  * does not need to launch any Java threads.
+  */
+class SingleThreadBackend[T <: Module](
+  val dut:                T,
+  val dataNames:          Map[Data, String],
+  val combinationalPaths: Map[Data, Set[Data]],
+  tester:                 SimulatorContext,
+  coverageAnnotations:    AnnotationSeq)
+    extends BackendInstance[T] {
+
+  //
+  // Debug utility functions
+  //
+  private val verbose: Boolean = false // hard-coded debug flag
+  private def debugLog(str: => String): Unit = {
+    if (verbose) println(str)
+  }
+
+  private def resolveName(signal: Data): String = { // TODO: unify w/ dataNames?
+    dataNames.getOrElse(signal, signal.toString)
+  }
+
+  //
+  // Circuit introspection functionality
+  //
+  override def getSourceClocks(signal: Data): Set[Clock] = {
+    throw new ClockResolutionException("ICR not available on chisel-testers2 / firrtl master")
+  }
+
+  override def getSinkClocks(signal: Data): Set[Clock] = {
+    throw new ClockResolutionException("ICR not available on chisel-testers2 / firrtl master")
+  }
+
+  //
+  // Everything else
+  //
+
+  override def pokeClock(signal: Clock, value: Boolean): Unit = {
+    throw new NotImplementedError("Poking clocks is currently no supported!")
+  }
+
+  override def peekClock(signal: Clock): Boolean = {
+    val a = tester.peek(dataNames(signal))
+    debugLog(s"${resolveName(signal)} -> $a")
+    a > 0
+  }
+
+  override def pokeBits(signal: Data, value: BigInt): Unit = {
+    tester.poke(dataNames(signal), value)
+    debugLog(s"${resolveName(signal)} <- $value")
+  }
+
+  override def peekBits(signal: Data, stale: Boolean): BigInt = {
+    require(!stale, "Stale peek not yet implemented")
+    val a = tester.peek(dataNames(signal))
+    debugLog(s"${resolveName(signal)} -> $a")
+    a
+  }
+
+  override def expectBits(
+    signal:  Data,
+    value:   BigInt,
+    message: Option[String],
+    decode:  Option[BigInt => String],
+    stale:   Boolean
+  ): Unit = {
+    require(!stale, "Stale peek not yet implemented")
+    debugLog(s"${resolveName(signal)} ?> $value")
+    Context().env.testerExpect(value, peekBits(signal, stale), resolveName(signal), message, decode)
+  }
+
+  override def doTimescope(contents: () => Unit): Unit = {
+    throw new NotImplementedError("This backend does not support timescopes!")
+  }
+
+  override def doFork(runnable: () => Unit, name: Option[String], region: Option[Region]) = {
+    throw new NotImplementedError("This backend does not support threads!")
+  }
+
+  override def doJoin(threads: Seq[AbstractTesterThread], stepAfter: Option[Clock]): Unit = {
+    throw new NotImplementedError("This backend does not support threads!")
+  }
+
+  override def step(signal: Clock, cycles: Int): Unit = {
+    require(signal == dut.clock)
+    tester.step(cycles)
+  }
+
+  override def setTimeout(signal: Clock, cycles: Int): Unit = {
+    require(signal == dut.clock, "timeout currently only supports master clock")
+    throw new NotImplementedError("No timeout support atm")
+  }
+
+  override def run(testFn: T => Unit): AnnotationSeq = {
+    try {
+      // default reset
+      tester.poke("reset", 1)
+      tester.step(1)
+      tester.poke("reset", 0)
+
+      // execute use code
+      testFn(dut)
+    } finally {
+      tester.finish() // needed to dump VCDs + terminate any external process
+    }
+
+    if (tester.sim.supportsCoverage) {
+      generateTestCoverageAnnotation() +: coverageAnnotations
+    } else { Seq() }
+  }
+
+  /** Generates an annotation containing the map from coverage point names to coverage counts. */
+  private def generateTestCoverageAnnotation(): TestCoverage = {
+    TestCoverage(tester.getCoverage())
+  }
+
+}

--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -41,6 +41,16 @@ case object CachingAnnotation extends TestOptionObject {
   )
 }
 
+case object UseThreads extends TestOptionObject {
+  val options: Seq[ShellOption[_]] = Seq(
+    new ShellOption[Unit](
+      longOption = "t-use-threads",
+      toAnnotationSeq = _ => Seq(UseThreads),
+      helpText = "enable fork and timescope constructs for your test"
+    )
+  )
+}
+
 object Context {
   class Instance(val backend: BackendInterface, val env: TestEnvInterface) {}
 

--- a/src/test/scala/chiseltest/benchmark/ChiseltestBenchmark.scala
+++ b/src/test/scala/chiseltest/benchmark/ChiseltestBenchmark.scala
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.benchmark
+
+import chiseltest._
+import chisel3._
+import chiseltest.simulator.SimulatorAnnotation
+import chiseltest.simulator.benchmark.DecoupledGcd
+import firrtl.options.TargetDirAnnotation
+import treadle.chronometry.Timer
+
+object ChiseltestBenchmark extends App {
+  private def computeGcd(a: BigInt, b: BigInt): BigInt = a.gcd(b)
+
+  private def runTest(dut: DecoupledGcd, testValues: Iterable[(BigInt, BigInt, BigInt)]): Long = {
+    var cycles = 0L
+    dut.reset.poke(true.B)
+    dut.clock.step(2)
+    cycles += 2
+    dut.reset.poke(false.B)
+
+    dut.output.ready.poke(true.B)
+    for((i, j, expected) <- testValues) {
+      dut.input.bits.value1.poke(i.U)
+      dut.input.bits.value2.poke(j.U)
+      dut.input.valid.poke(true.B)
+      dut.clock.step(1)
+      cycles += 1
+
+      while(!dut.output.valid.peek().litToBoolean) {
+        dut.clock.step(1)
+        cycles += 1
+      }
+      dut.output.bits.gcd.expect(expected.U)
+      dut.output.valid.expect(true.B)
+    }
+
+    cycles
+  }
+
+  // select and load simulator
+  val sim: SimulatorAnnotation = args.headOption match {
+    case None => VerilatorBackendAnnotation
+    case Some(name) => name.toLowerCase match {
+      case "verilator" => VerilatorBackendAnnotation
+      case "treadle" => TreadleBackendAnnotation
+      case "iverilog" => IcarusBackendAnnotation
+      case "vcd" => VcsBackendAnnotation
+      case other => throw new RuntimeException(s"Unknown simulator option: $other")
+    }
+  }
+  val simName = sim.getSimulator.name
+
+  val targetDir = TargetDirAnnotation("test_run_dir/gcd_benchmark_chiseltest_and_" + simName)
+  val annos = Seq(targetDir, sim)
+
+  val repetitions = 6
+  val numMax = 100
+  val testValues = for {x <- 2 to numMax; y <- 2 to numMax} yield (BigInt(x), BigInt(y), computeGcd(x, y))
+  val t = new Timer
+  var cycles = 0L
+
+  RawTester.test(new DecoupledGcd(bitWidth = 60), annos) { dut =>
+    (0 until repetitions).foreach { _ =>
+      t("sim-gcd-chiseltest-" + simName) {
+        cycles += runTest(dut, testValues)
+      }
+    }
+  }
+
+  println(t.report())
+  println(s"$cycles cycles")
+}

--- a/src/test/scala/chiseltest/benchmark/ChiseltestBenchmark.scala
+++ b/src/test/scala/chiseltest/benchmark/ChiseltestBenchmark.scala
@@ -4,6 +4,7 @@ package chiseltest.benchmark
 
 import chiseltest._
 import chisel3._
+import chiseltest.internal.UseThreads
 import chiseltest.simulator.SimulatorAnnotation
 import chiseltest.simulator.benchmark.DecoupledGcd
 import firrtl.options.TargetDirAnnotation
@@ -55,7 +56,7 @@ object ChiseltestBenchmark extends App {
   val annos = Seq(targetDir, sim)
 
   val repetitions = 6
-  val numMax = 100
+  val numMax = 200
   val testValues = for {x <- 2 to numMax; y <- 2 to numMax} yield (BigInt(x), BigInt(y), computeGcd(x, y))
   val t = new Timer
   var cycles = 0L


### PR DESCRIPTION
I am trying to see what the impact of using a single threaded backend by default would be. This could be an alternative to adapting a `PeekPokeTester` compatibility API since performance for single threaded tests seems to be the major concern that keeps users from switching.

So far, on the GCD benchmark the numbers (with verilator) are:
- plain SimulatorContext: 8.6s
- chiseltest w/ the ThreadedBackend: 282s
- chiseltest w/ the SingleThreadBackend: 12s