### PR TITLE
ci: reorganize into more independent jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,12 @@ on:
 
 jobs:
   test:
-    name: sbt test
-    runs-on: ${{ matrix.os }}
+    name: sbt test on ubuntu
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
         scala: [2.12.13, 2.13.5]
         jvm: [adopt@1.8, adopt@1.11]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,6 +24,19 @@ jobs:
           java-version: ${{ matrix.jvm }}
       - name: Test
         run: sbt ++${{ matrix.scala }} "testOnly -- -l RequiresVcs -l RequiresVerilator -l Formal -l RequiresIcarus"
+
+  test-mac:
+    name: sbt test on mac
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Test
+        run: sbt "testOnly -- -l RequiresVcs -l RequiresVerilator -l Formal -l RequiresIcarus"
 
   icarus:
     name: icarus verilog
@@ -114,7 +125,7 @@ jobs:
         with:
           java-version: adopt@1.8
       - name: Test
-        run: sbt "testOnly chiseltest.backends.verilator.** ; testOnly -- -n RequiresVerilator"
+        run: sbt "testOnly -- -n RequiresVerilator"
 
   formal:
     name: formal verification tests
@@ -166,7 +177,7 @@ jobs:
   # When adding new jobs, please add them to `needs` below
   all_tests_passed:
     name: "all tests passed"
-    needs: [test, doc, verilator, verilator-mac, formal, icarus]
+    needs: [test, doc, verilator, verilator-mac, formal, icarus, test-mac]
     runs-on: ubuntu-latest
     steps:
       - run: echo Success!

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,25 +20,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Verilator and Icarus Verilog for Ubuntu
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y verilator iverilog
-          verilator --version
-          iverilog -v || true
-      - name: Install Verilator and Icarus Verilog for MacOS
-        if: runner.os == 'macOS'
-        run: |
-          brew install verilator
-          brew install icarus-verilog
-          verilator --version
-          iverilog -v || true
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jvm }}
       - name: Test
-        run: sbt ++${{ matrix.scala }} "testOnly -- -l RequiresVcs -l RequiresVerilator -l Formal"
+        run: sbt ++${{ matrix.scala }} "testOnly -- -l RequiresVcs -l RequiresVerilator -l Formal -l RequiresIcarus"
+
+  icarus:
+    name: icarus verilog
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, macos-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Icarus Verilog for Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y iverilog
+          iverilog -v || true
+      - name: Install Icarus Verilog for MacOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install icarus-verilog
+          iverilog -v || true
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Test
+        run: sbt ++${{ matrix.scala }} "testOnly -- -n RequiresIcarus"
 
   verilator-mac:
     name: verilator regression on mac
@@ -55,7 +68,7 @@ jobs:
         with:
           java-version: adopt@1.11
       - name: Test
-        run: sbt "testOnly chiseltest.backends.verilator.** ; testOnly -- -n RequiresVerilator"
+        run: sbt "testOnly -- -n RequiresVerilator"
 
   verilator:
     name: verilator regressions
@@ -153,7 +166,7 @@ jobs:
   # When adding new jobs, please add them to `needs` below
   all_tests_passed:
     name: "all tests passed"
-    needs: [test, doc, verilator, verilator-mac, formal]
+    needs: [test, doc, verilator, verilator-mac, formal, icarus]
     runs-on: ubuntu-latest
     steps:
       - run: echo Success!

--- a/src/test/scala/chiseltest/backends/verilator/VerilatorBasicTests.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorBasicTests.scala
@@ -4,6 +4,7 @@ package chiseltest.backends.verilator
 import chisel3._
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
+import chiseltest.simulator.RequiresVerilator
 import chiseltest.tests.{PassthroughModule, StaticModule}
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,13 +15,13 @@ class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Ma
 
   val annos = Seq(VerilatorBackendAnnotation)
 
-  it should "test static circuits" in {
+  it should "test static circuits" taggedAs RequiresVerilator in {
     test(new StaticModule(42.U)).withAnnotations(annos) { c =>
       c.out.expect(42.U)
     }
   }
 
-  it should "fail on poking outputs" in {
+  it should "fail on poking outputs" taggedAs RequiresVerilator in {
     assertThrows[UnpokeableException] {
       test(new StaticModule(42.U)).withAnnotations(annos) { c =>
         c.out.poke(0.U)
@@ -28,7 +29,7 @@ class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Ma
     }
   }
 
-  it should "fail on expect mismatch" in {
+  it should "fail on expect mismatch" taggedAs RequiresVerilator in {
     assertThrows[exceptions.TestFailedException] {
       test(new StaticModule(42.U)).withAnnotations(annos) { c =>
         c.out.expect(0.U)
@@ -36,7 +37,7 @@ class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Ma
     }
   }
 
-  it should "fail with user-defined message" in {
+  it should "fail with user-defined message" taggedAs RequiresVerilator in {
     intercept[exceptions.TestFailedException] {
       test(new StaticModule(42.U)).withAnnotations(annos) { c =>
         c.out.expect(0.U, "user-defined failure message =(")
@@ -44,7 +45,7 @@ class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Ma
     }.getMessage should include ("user-defined failure message =(")
   }
 
-  it should "test inputless sequential circuits" in {
+  it should "test inputless sequential circuits" taggedAs RequiresVerilator in {
     test(new Module {
       val io = IO(new Bundle {
         val out = Output(UInt(8.W))
@@ -63,7 +64,7 @@ class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Ma
     }
   }
 
-  it should "test combinational circuits" in {
+  it should "test combinational circuits" taggedAs RequiresVerilator in {
     test(new PassthroughModule(UInt(8.W))).withAnnotations(annos) { c =>
       c.in.poke(0.U)
       c.out.expect(0.U)
@@ -72,7 +73,7 @@ class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Ma
     }
   }
 
-  it should "test sequential circuits" in {
+  it should "test sequential circuits" taggedAs RequiresVerilator in {
     test(new Module {
       val io = IO(new Bundle {
         val in = Input(UInt(8.W))
@@ -89,7 +90,7 @@ class VerilatorBasicTests extends AnyFlatSpec with ChiselScalatestTester with Ma
     }
   }
 
-  it should "test reset" in {
+  it should "test reset" taggedAs RequiresVerilator in {
     test(new Module {
       val io = IO(new Bundle {
         val in = Input(UInt(8.W))

--- a/src/test/scala/chiseltest/backends/verilator/VerilatorCachingTests.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorCachingTests.scala
@@ -6,6 +6,7 @@ import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.experimental.sanitizeFileName
 import chiseltest.internal.CachingAnnotation
+import chiseltest.simulator.RequiresVerilator
 import chiseltest.utils.CaptureStdout
 import chiseltest.tests.StaticModule
 import firrtl.AnnotationSeq
@@ -24,13 +25,13 @@ class VerilatorCachingTests extends AnyFlatSpec with ChiselScalatestTester with 
     })._2
   }
 
-  it should "re-compile by default" in {
+  it should "re-compile by default" taggedAs RequiresVerilator in {
     startWithEmptyTestDir()
     // by default no reuse should occur
     (0 until 3).foreach { _ => assert(runTest(42, default) == 0) }
   }
 
-  it should "not re-compile when caching is enabled" in {
+  it should "not re-compile when caching is enabled" taggedAs RequiresVerilator in {
     startWithEmptyTestDir()
     // the first time no re-use occurs
     assert(runTest(42, withCaching) == 0)
@@ -39,7 +40,7 @@ class VerilatorCachingTests extends AnyFlatSpec with ChiselScalatestTester with 
     assert(runTest(42, withCaching) == 1)
   }
 
-  it should "not cache when two different modules are instantiated" in {
+  it should "not cache when two different modules are instantiated" taggedAs RequiresVerilator in {
     startWithEmptyTestDir()
     // this generates a cache
     println("StaticModule(42)")

--- a/src/test/scala/chiseltest/backends/verilator/VerilatorClockPokeTest.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorClockPokeTest.scala
@@ -6,6 +6,7 @@ import chisel3.util._
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.experimental.UncheckedClockPoke._
+import chiseltest.simulator.RequiresVerilator
 import org.scalatest.flatspec.AnyFlatSpec
 import treadle.executable.ClockInfo
 import treadle.{ClockInfoAnnotation, WriteVcdAnnotation}
@@ -13,7 +14,7 @@ import treadle.{ClockInfoAnnotation, WriteVcdAnnotation}
 class VerilatorClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Testers2 with a clock input"
 
-  it should "verilator-clock-poke" ignore { // TODO: re-add multi clock support
+  it should "verilator-clock-poke" taggedAs RequiresVerilator ignore { // TODO: re-add multi clock support
     test(new Module {
       val inClock = IO(Input(Clock()))
       val out = IO(Output(UInt(8.W)))
@@ -50,7 +51,7 @@ class VerilatorClockPokeTest extends AnyFlatSpec with ChiselScalatestTester {
     }
   }
 
-  it should "clock-as-bool-verilator-clock-poke" ignore { // TODO: re-add multi clock support
+  it should "clock-as-bool-verilator-clock-poke" taggedAs RequiresVerilator ignore { // TODO: re-add multi clock support
     test(new Module {
       val inClock = IO(Input(Bool()))
       val out = IO(Output(UInt(8.W)))

--- a/src/test/scala/chiseltest/backends/verilator/VerilatorCoverageTest.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorCoverageTest.scala
@@ -4,5 +4,6 @@ package chiseltest.backends.verilator
 
 import chiseltest.VerilatorBackendAnnotation
 import chiseltest.coverage.SimulatorCoverageTest
+import chiseltest.simulator.RequiresVerilator
 
-class VerilatorCoverageTest extends SimulatorCoverageTest("Verilator", VerilatorBackendAnnotation) {}
+class VerilatorCoverageTest extends SimulatorCoverageTest("Verilator", VerilatorBackendAnnotation, RequiresVerilator) {}

--- a/src/test/scala/chiseltest/backends/verilator/VerilatorCoverageTests.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilatorCoverageTests.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
 import chiseltest.experimental.sanitizeFileName
-import chiseltest.simulator.VerilatorFlags
+import chiseltest.simulator.{RequiresVerilator, VerilatorFlags}
 import firrtl.AnnotationSeq
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,7 +22,7 @@ private class TestModule extends Module {
 class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
-  it should "allow specifying Verilog toggle coverage for Verilator" in {
+  it should "allow specifying Verilog toggle coverage for Verilator" taggedAs RequiresVerilator in {
     clean()
     val annos = Seq(VerilatorBackendAnnotation, VerilatorFlags(Seq("--coverage-toggle")))
     runTest(annos)
@@ -32,7 +32,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     assert(counts.line == 0)
   }
 
-  it should "allow specifying Verilog line coverage for Verilator" in {
+  it should "allow specifying Verilog line coverage for Verilator" taggedAs RequiresVerilator in {
     clean()
     val annos = Seq(VerilatorBackendAnnotation, VerilatorFlags(Seq("--coverage-line")))
     runTest(annos)
@@ -42,7 +42,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     assert(counts.line == 3 || counts.line == 1) // different verilator versions add different numbers of cover points
   }
 
-  it should "allow specifying Verilog structural coverage for Verilator" in {
+  it should "allow specifying Verilog structural coverage for Verilator" taggedAs RequiresVerilator in {
     clean()
     val annos = Seq(VerilatorBackendAnnotation, VerilatorFlags(Seq("--coverage-toggle", "--coverage-line")))
     runTest(annos)
@@ -52,7 +52,7 @@ class VerilatorCoverageTests extends AnyFlatSpec with ChiselScalatestTester with
     assert(counts.line == 3 || counts.line == 1) // different verilator versions add different numbers of cover points
   }
 
-  it should "always generate user coverage" in {
+  it should "always generate user coverage" taggedAs RequiresVerilator in {
     clean()
     val annos = Seq(VerilatorBackendAnnotation)
     runTest(annos)

--- a/src/test/scala/chiseltest/backends/verilator/VerilogBlackBoxTest.scala
+++ b/src/test/scala/chiseltest/backends/verilator/VerilogBlackBoxTest.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.util._
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
+import chiseltest.simulator.RequiresVerilator
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.util.Random
@@ -38,7 +39,7 @@ class VerilogBlackBoxTest extends AnyFlatSpec with ChiselScalatestTester {
 
   val annos = Seq(VerilatorBackendAnnotation)
 
-  it should "support Verilog black boxes" in {
+  it should "support Verilog black boxes" taggedAs RequiresVerilator in {
     val rand = new Random()
     val mask = (BigInt(1) << 8) - 1
     test(new BlackBoxAdderWrapper).withAnnotations(annos) { dut =>

--- a/src/test/scala/chiseltest/coverage/SimulatorCoverageTest.scala
+++ b/src/test/scala/chiseltest/coverage/SimulatorCoverageTest.scala
@@ -8,16 +8,17 @@ import chiseltest._
 import firrtl.AnnotationSeq
 import org.scalatest.flatspec.AnyFlatSpec
 import chisel3._
-import chiseltest.simulator.SimulatorAnnotation
+import chiseltest.simulator.{DefaultTag, SimulatorAnnotation}
+import org.scalatest.Tag
 
 /** Ensure that all simulators give the same coverage feedback when run with the same tests.
   * To implement this for a particular simulator, just override the `backend` annotation.
   * */
-abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation) extends AnyFlatSpec with ChiselScalatestTester {
+abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation, tag: Tag = DefaultTag) extends AnyFlatSpec with ChiselScalatestTester {
   behavior of s"$name Coverage Collection"
   private def noAutoCov: AnnotationSeq = Seq(backend)
 
-  it should "report count for all user cover points (no submodules)" in {
+  it should "report count for all user cover points (no submodules)" taggedAs tag in {
     val r = test(new Test1Module(withSubmodules = false)).withAnnotations(noAutoCov) { dut =>
       dut.clock.step()
     }
@@ -30,7 +31,7 @@ abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation)
     assert(cov("SIM") == 2)
   }
 
-  it should "report count for all user cover points (with submodules)" in {
+  it should "report count for all user cover points (with submodules)" taggedAs tag in {
     val r = test(new Test1Module(withSubmodules = true)).withAnnotations(noAutoCov) { dut =>
       dut.clock.step()
     }
@@ -46,7 +47,7 @@ abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation)
   }
 
   // this is an integration test that uses chisel3.experimental.verification.cover to estimate PI
-  it should "allow us to estimate pi" in {
+  it should "allow us to estimate pi" taggedAs tag in {
     val rand = new scala.util.Random(0)
     val r = test(new PiEstimator).withAnnotations(noAutoCov) { dut =>
       (0 until 1000).foreach { _ =>

--- a/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/NegativeInputValuesTest.scala
@@ -5,6 +5,7 @@ package chiseltest.experimental.tests
 import chisel3._
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder._
+import chiseltest.simulator.RequiresVerilator
 import org.scalatest.freespec.AnyFreeSpec
 
 class HasOddWidthSInt extends Module {
@@ -20,7 +21,7 @@ class HasOddWidthSInt extends Module {
 // would break in verilator if the poked value was not masked to the correct number of
 // bits first. This was fixed by masking those values to the proper width before poking
 class NegativeInputValuesTest extends AnyFreeSpec with ChiselScalatestTester {
-  "Negative input values on odd width SInt should not cause verilator to fail" in {
+  "Negative input values on odd width SInt should not cause verilator to fail" taggedAs RequiresVerilator in {
     test(new HasOddWidthSInt).withAnnotations(Seq(VerilatorBackendAnnotation)) { dut =>
       for(inputValue <- Seq(-4, -3, -2, -1, 0, 1, 2, 3, 4)) {
         dut.in.poke(inputValue.S)

--- a/src/test/scala/chiseltest/simulator/ComplianceTest.scala
+++ b/src/test/scala/chiseltest/simulator/ComplianceTest.scala
@@ -21,4 +21,4 @@ abstract class ComplianceTest(sim: Simulator, protected val tag: Tag) extends Fl
 }
 
 // a hack for when we do not actually want to tag the tests
-private object DefaultTag extends Tag("DefaultTag")
+object DefaultTag extends Tag("DefaultTag")

--- a/src/test/scala/chiseltest/simulator/Icarus.scala
+++ b/src/test/scala/chiseltest/simulator/Icarus.scala
@@ -3,15 +3,18 @@
 package chiseltest.simulator
 
 import chiseltest.utils.CaptureStdout
+import org.scalatest.Tag
 import org.scalatest.flatspec.AnyFlatSpec
 
+/** To disable tests that require the Icarus Verilog simulator use the following: `sbt testOnly -- -l RequiresIcarus` */
+object RequiresIcarus extends Tag("RequiresIcarus")
 
-class IcarusBasicCompliance extends BasicCompliance(IcarusSimulator)
-class IcarusStepCompliance extends StepCompliance(IcarusSimulator)
-class IcarusPeekPokeCompliance extends PeekPokeCompliance(IcarusSimulator)
-class IcarusWaveformCompliance extends WaveformCompliance(IcarusSimulator)
-class IcarusCoverageCompliance extends CoverageCompliance(IcarusSimulator)
-class IcarusMemoryCompliance extends MemoryCompliance(IcarusSimulator)
+class IcarusBasicCompliance extends BasicCompliance(IcarusSimulator, RequiresIcarus)
+class IcarusStepCompliance extends StepCompliance(IcarusSimulator, RequiresIcarus)
+class IcarusPeekPokeCompliance extends PeekPokeCompliance(IcarusSimulator, RequiresIcarus)
+class IcarusWaveformCompliance extends WaveformCompliance(IcarusSimulator, RequiresIcarus)
+class IcarusCoverageCompliance extends CoverageCompliance(IcarusSimulator, RequiresIcarus)
+class IcarusMemoryCompliance extends MemoryCompliance(IcarusSimulator, RequiresIcarus)
 
 
 class IcarusSpecificTests extends AnyFlatSpec {
@@ -19,7 +22,7 @@ class IcarusSpecificTests extends AnyFlatSpec {
 
   private val sim = IcarusSimulator
 
-  it should "print a version" in {
+  it should "print a version" taggedAs RequiresIcarus in {
     val (_, out) = CaptureStdout {
       sim.findVersions
     }

--- a/src/test/scala/chiseltest/simulator/MemoryCompliance.scala
+++ b/src/test/scala/chiseltest/simulator/MemoryCompliance.scala
@@ -44,17 +44,17 @@ abstract class MemoryCompliance(sim: Simulator, tag: Tag = DefaultTag) extends C
     dut.finish()
   }
 
-  it should "support initializing a memory with a scalar constant" in {
+  it should "support initializing a memory with a scalar constant" taggedAs tag in {
     val dut = load(readMem, Seq(MemoryScalarInitAnnotation(mRef, 123)))
     checkMem(dut, Seq(123, 123, 123))
   }
 
-  it should "support initializing a memory with a list" in {
+  it should "support initializing a memory with a list" taggedAs tag in {
     val dut = load(readMem, Seq(MemoryArrayInitAnnotation(mRef, Seq(123, 231, 234))))
     checkMem(dut, Seq(123, 231, 234))
   }
 
-  it should "support initializing a memory from a file" in {
+  it should "support initializing a memory from a file" taggedAs tag in {
     val dut = load(readMem, Seq(MemoryFileInlineAnnotation(mRef, "src/test/resources/init.mem")))
     checkMem(dut, Seq(0xab, 0xcd, 0xef))
   }

--- a/src/test/scala/chiseltest/simulator/Verilator.scala
+++ b/src/test/scala/chiseltest/simulator/Verilator.scala
@@ -21,7 +21,7 @@ class VerilatorSpecificTests extends AnyFlatSpec {
 
   private val sim = VerilatorSimulator
 
-  it should "print the version that we depend on" in {
+  it should "print the version that we depend on" taggedAs RequiresVerilator in {
     val (_, out) = CaptureStdout {
       sim.findVersions
     }

--- a/src/test/scala/chiseltest/tests/VerilogBlackBoxTests.scala
+++ b/src/test/scala/chiseltest/tests/VerilogBlackBoxTests.scala
@@ -3,10 +3,9 @@ package chiseltest.tests
 
 import chiseltest._
 import chiseltest.experimental.TestOptionBuilder.ChiselScalatestOptionBuilder
-
 import chisel3._
 import chisel3.util._
-
+import chiseltest.simulator.RequiresVerilator
 import org.scalatest.flatspec.AnyFlatSpec
 
 
@@ -22,7 +21,7 @@ class VerilogBlackBoxTests extends AnyFlatSpec with ChiselScalatestTester {
     dut.clock.step()
   }
 
-  it should "be copied over so that they are accessible to Verilator" in {
+  it should "be copied over so that they are accessible to Verilator"  taggedAs RequiresVerilator in {
     test(new UsesBBAddOne).withAnnotations(Seq(VerilatorBackendAnnotation))(doTest)
   }
 }


### PR DESCRIPTION
This also cuts down on the number of `mac` jobs we run because those machines seem to be harder to get.