### PR TITLE
  simulator: define common API for stop/assert/assume interrupts 

### DIFF
--- a/src/main/scala/chiseltest/exceptions.scala
+++ b/src/main/scala/chiseltest/exceptions.scala
@@ -14,3 +14,9 @@ class TimeoutException(message: String) extends Exception(message)
 
 // when interfacing with the testdriver before stepping the clock after moving to an earlier region
 class TemporalParadox(message: String) extends Exception(message)
+
+/** Indicates that a Chisel `stop()` statement was triggered. */
+class StopException(message: String) extends Exception(message)
+
+/** Indicates that a Chisel `assert(...)` or `assume(...)` statement has failed. */
+class ChiselAssertionError(message: String) extends Exception(message)

--- a/src/main/scala/chiseltest/simulator/DebugPrintWrapper.scala
+++ b/src/main/scala/chiseltest/simulator/DebugPrintWrapper.scala
@@ -7,11 +7,12 @@ package chiseltest.simulator
 class DebugPrintWrapper(inner: SimulatorContext) extends SimulatorContext {
   private var cycle: Long = 0
   override def sim = inner.sim
-  override def step(n: Int): Unit = {
+  override def step(n: Int): StepResult = {
     val start = cycle
     cycle += n
-    inner.step(n)
+    val res = inner.step(n)
     println(s"step $start -> $cycle")
+    res
   }
   override def peek(signal: String) = {
     val res = inner.peek(signal)

--- a/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
@@ -61,16 +61,23 @@ private class TreadleContext(tester: TreadleTester, toplevel: TopmoduleInfo) ext
 
   require(toplevel.clocks.size <= 1, "Currently only single clock circuits are supported!")
   private def defaultClock = toplevel.clocks.headOption
-  override def step(n: Int): Unit = {
+  override def step(n: Int): StepResult = {
     defaultClock match {
       case Some(_) =>
       case None    => throw NoClockException(tester.topName)
     }
+    var delta: Int = 0
     try {
-      tester.step(n = n)
+      (0 until n).foreach { _ =>
+        delta += 1
+        tester.step()
+      }
+      StepOk
     } catch {
-      case _: StopException =>
-      // TODO: throw exception!
+      case s: StopException =>
+        val infos = s.stops.map(_.name)
+        val isFailure = s.stops.exists(_.ret > 0)
+        StepInterrupted(delta, isFailure, infos)
     }
   }
 

--- a/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VerilatorSimulator.scala
@@ -176,6 +176,8 @@ private object VerilatorSimulator extends Simulator {
 
   private def DefaultCFlags(topName: String) = List(
     "-O1",
+    "-DVL_USER_STOP",
+    "-DVL_USER_FATAL",
     "-DVL_USER_FINISH", // this is required because we ant to overwrite the vl_finish function!
     s"-DTOP_TYPE=V$topName",
     s"-include V$topName.h"

--- a/src/main/scala/chiseltest/simulator/ipc/IPCSimulatorContext.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/IPCSimulatorContext.scala
@@ -339,17 +339,22 @@ private[chiseltest] class IPCSimulatorContext(
   }
 
   private def defaultClock = toplevel.clocks.headOption
-  override def step(n: Int): Unit = {
+  override def step(n: Int): StepResult = {
     defaultClock match {
       case Some(value) =>
       case None        => throw NoClockException(toplevel.name)
     }
+    var delta: Int = 0
     try {
       update()
-      (0 until n).foreach(_ => takeStep())
+      (0 until n).foreach { _ =>
+        delta += 1
+        takeStep()
+      }
+      StepOk
     } catch {
       case TestApplicationException(exit, msg) =>
-      // TODO: throw exception
+        StepInterrupted(delta, exit != 0, List())
     }
   }
 

--- a/src/main/scala/chiseltest/simulator/jna/JNAUtils.scala
+++ b/src/main/scala/chiseltest/simulator/jna/JNAUtils.scala
@@ -35,7 +35,7 @@ object JNAUtils {
 
   /** needs to match up with [[TesterSharedLibInterface]]! */
   val Methods = Seq(
-    ("void", "step", Seq()),
+    ("long", "step", Seq()),
     ("void", "update", Seq()),
     ("void", "finish", Seq()),
     ("void", "resetCoverage", Seq()),
@@ -111,7 +111,7 @@ object JNAUtils {
 
 class TesterSharedLibInterface(so: NativeLibrary, sPtr: Pointer) {
   private val stepFoo = so.getFunction("step")
-  def step(): Unit = { stepFoo.invoke(Array(sPtr)) }
+  def step(): Long = { stepFoo.invokeLong(Array(sPtr)) }
   private val updateFoo = so.getFunction("update")
   def update(): Unit = { updateFoo.invoke(Array(sPtr)) }
   private val finishFoo = so.getFunction("finish")

--- a/src/test/scala/chiseltest/simulator/Icarus.scala
+++ b/src/test/scala/chiseltest/simulator/Icarus.scala
@@ -15,7 +15,9 @@ class IcarusPeekPokeCompliance extends PeekPokeCompliance(IcarusSimulator, Requi
 class IcarusWaveformCompliance extends WaveformCompliance(IcarusSimulator, RequiresIcarus)
 class IcarusCoverageCompliance extends CoverageCompliance(IcarusSimulator, RequiresIcarus)
 class IcarusMemoryCompliance extends MemoryCompliance(IcarusSimulator, RequiresIcarus)
-
+// VPI based simulators are currently not Stop compliant, they will just exit once they encounter a stop
+// or a failed assertion
+//class IcarusStopCompliance extends StopCompliance(IcarusSimulator, RequiresIcarus)
 
 class IcarusSpecificTests extends AnyFlatSpec {
   behavior of "iverilog"

--- a/src/test/scala/chiseltest/simulator/StopAssertAssumeCompliance.scala
+++ b/src/test/scala/chiseltest/simulator/StopAssertAssumeCompliance.scala
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.simulator
+
+import org.scalatest.Tag
+
+/** Ensures that the `step` function works correctly, no or one clock. */
+abstract class StopAssertAssumeCompliance(sim: Simulator, tag: Tag = DefaultTag) extends ComplianceTest(sim, tag) {
+  private val src =
+    """circuit test:
+      |  module child:
+      |    input clock: Clock
+      |    input stop0En: UInt<1>
+      |    input stop1En: UInt<1>
+      |    input stop2En: UInt<1>
+      |    input stop3En: UInt<1>
+      |
+      |    stop(clock, stop0En, 0) : stop0
+      |    stop(clock, stop1En, 1) : stop1
+      |    assert(clock, UInt(0), stop2En, "") : stop2
+      |    assume(clock, UInt(0), stop3En, "") : stop3
+      |
+      |  module test:
+      |    input clock: Clock
+      |    input stop0En: UInt<1>
+      |    input stop1En: UInt<1>
+      |    input stop2En: UInt<1>
+      |    input stop3En: UInt<1>
+      |    input selParent: UInt<1>
+      |    input selChild0: UInt<1>
+      |    input selChild1: UInt<1>
+      |
+      |    when selParent:
+      |      stop(clock, stop0En, 0) : stop0
+      |      stop(clock, stop1En, 1) : stop1
+      |      assert(clock, UInt(0), stop2En, "") : stop2
+      |      assume(clock, UInt(0), stop3En, "") : stop3
+      |
+      |    inst c0 of child
+      |    c0.clock <= clock
+      |    c0.stop0En <= and(selChild0, stop0En)
+      |    c0.stop1En <= and(selChild0, stop1En)
+      |    c0.stop2En <= and(selChild0, stop2En)
+      |    c0.stop3En <= and(selChild0, stop3En)
+      |
+      |    inst c1 of child
+      |    c1.clock <= clock
+      |    c1.stop0En <= and(selChild1, stop0En)
+      |    c1.stop1En <= and(selChild1, stop1En)
+      |    c1.stop2En <= and(selChild1, stop2En)
+      |    c1.stop3En <= and(selChild1, stop3En)
+      |""".stripMargin
+
+  private def start(withVCD: Boolean = false): SimulatorContext = {
+    val annos = if(withVCD) Seq(WriteVcdAnnotation) else Seq()
+    val dut = load(src, annos)
+    // set every input to zero by default
+    dut.poke("stop0En", 0)
+    dut.poke("stop1En", 0)
+    dut.poke("stop2En", 0)
+    dut.poke("stop3En", 0)
+    dut.poke("selParent", 0)
+    dut.poke("selChild0", 0)
+    dut.poke("selChild1", 0)
+    assert(dut.step() == StepOk)
+    dut
+  }
+
+  it should "not throw an exception if the stop is only triggered combinatorially" taggedAs tag in {
+    val dut = start()
+    dut.poke("selParent", 1)
+
+    (0 until 4).foreach { ii =>
+      dut.poke(s"stop${ii}En", 1)
+      // no step
+      dut.poke(s"stop${ii}En", 0)
+      assert(dut.step() == StepOk)
+    }
+    dut.finish()
+  }
+
+  it should "throw a StopException when encountering a stop during a step" taggedAs tag in {
+    val dut = start(true)
+    dut.poke("selParent", 1) // we are only testing the parent module
+
+    dut.poke("stop0En", 1)
+    dut.poke("stop1En", 1)
+    dut.poke("stop2En", 1)
+    dut.poke("stop3En", 1)
+    val r0 = dut.step()
+    assert(r0.asInstanceOf[StepInterrupted].after == 1)
+    assert(r0.asInstanceOf[StepInterrupted].isFailure)
+    if(sim == TreadleSimulator) { // only treadle will report the exact statements that were triggered
+      assert(r0.asInstanceOf[StepInterrupted].sources == List("stop0", "stop1", "stop2", "stop3"))
+    }
+
+    dut.poke("stop0En", 0)
+    dut.poke("stop1En", 0)
+    dut.poke("stop2En", 0)
+    dut.poke("stop3En", 0)
+    assert(dut.step() == StepOk)
+
+    // only a stop(0) is not considered a failure
+    dut.poke("stop0En", 1)
+    val r1 = dut.step()
+    assert(r1.asInstanceOf[StepInterrupted].after == 1)
+    assert(!r1.asInstanceOf[StepInterrupted].isFailure)
+    if(sim == TreadleSimulator) { // only treadle will report the exact statements that were triggered
+      assert(r1.asInstanceOf[StepInterrupted].sources == List("stop0"))
+    }
+
+    dut.finish()
+  }
+
+  it should "throw a StopException when encountering a stop during a step in a child" taggedAs tag in {
+    val dut = start(true)
+    dut.poke("selChild0", 1) // we are only testing the parent module
+
+    dut.poke("stop0En", 1)
+    dut.poke("stop1En", 1)
+    dut.poke("stop2En", 1)
+    dut.poke("stop3En", 1)
+    val r0 = dut.step()
+    assert(r0.asInstanceOf[StepInterrupted].after == 1)
+    assert(r0.asInstanceOf[StepInterrupted].isFailure)
+    if(sim == TreadleSimulator) { // only treadle will report the exact statements that were triggered
+      assert(r0.asInstanceOf[StepInterrupted].sources == List("c0.stop0", "c0.stop1", "c0.stop2", "c0.stop3"))
+    }
+
+    dut.poke("stop0En", 0)
+    dut.poke("stop1En", 0)
+    dut.poke("stop2En", 0)
+    dut.poke("stop3En", 0)
+    assert(dut.step() == StepOk)
+
+    // only a stop(0) is not considered a failure
+    dut.poke("stop0En", 1)
+    dut.poke("stop1En", 0)
+    dut.poke("stop2En", 0)
+    dut.poke("stop3En", 0)
+    val r1 = dut.step()
+    assert(r1.asInstanceOf[StepInterrupted].after == 1)
+    assert(!r1.asInstanceOf[StepInterrupted].isFailure)
+    if(sim == TreadleSimulator) { // only treadle will report the exact statements that were triggered
+      assert(r1.asInstanceOf[StepInterrupted].sources == List("c0.stop0"))
+    }
+
+    dut.finish()
+  }
+
+}

--- a/src/test/scala/chiseltest/simulator/Treadle.scala
+++ b/src/test/scala/chiseltest/simulator/Treadle.scala
@@ -11,6 +11,7 @@ class TreadlePeekPokeCompliance extends PeekPokeCompliance(TreadleSimulator)
 class TreadleWaveformCompliance extends WaveformCompliance(TreadleSimulator)
 class TreadleCoverageCompliance extends CoverageCompliance(TreadleSimulator)
 class TreadleMemoryCompliance extends MemoryCompliance(TreadleSimulator)
+class TreadleStopAssertAssumeCompliance extends StopAssertAssumeCompliance(TreadleSimulator)
 
 class TreadleSpecificTests extends AnyFlatSpec {
   behavior of "treadle"

--- a/src/test/scala/chiseltest/simulator/Verilator.scala
+++ b/src/test/scala/chiseltest/simulator/Verilator.scala
@@ -15,6 +15,7 @@ class VerilatorPeekPokeCompliance extends PeekPokeCompliance(VerilatorSimulator,
 class VerilatorWaveformCompliance extends WaveformCompliance(VerilatorSimulator, RequiresVerilator)
 class VerilatorCoverageCompliance extends CoverageCompliance(VerilatorSimulator, RequiresVerilator)
 class VerilatorMemoryCompliance extends MemoryCompliance(VerilatorSimulator, RequiresVerilator)
+class VerilatorStopAssertAssumeCompliance extends StopAssertAssumeCompliance(VerilatorSimulator, RequiresVerilator)
 
 class VerilatorSpecificTests extends AnyFlatSpec {
   behavior of "verilator"

--- a/src/test/scala/chiseltest/tests/AssertTests.scala
+++ b/src/test/scala/chiseltest/tests/AssertTests.scala
@@ -19,7 +19,7 @@ class AssertTestBench() extends Module {
 class AssertTests extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "Assert"
 
-  val annotations = Seq(VerilatorBackendAnnotation, WriteVcdAnnotation)
+  val annotations = Seq(VerilatorBackendAnnotation)
 
   it should "not assert" taggedAs RequiresVerilator in {
     test(
@@ -27,6 +27,24 @@ class AssertTests extends AnyFlatSpec with ChiselScalatestTester {
     ).withAnnotations(annotations) { dut =>
       dut.io.enable.poke(false.B)
       dut.clock.step(1)
+    }
+  }
+
+  it should "assert (with treadle)" in {
+    assertThrows[ChiselAssertionError] {
+      test(new AssertTestBench()) { dut =>
+        dut.io.enable.poke(true.B)
+        dut.clock.step(1)
+      }
+    }
+  }
+
+  it should "assert (with verilator)" taggedAs RequiresVerilator in {
+    assertThrows[ChiselAssertionError] {
+      test(new AssertTestBench()).withAnnotations(annotations) { dut =>
+        dut.io.enable.poke(true.B)
+        dut.clock.step(1)
+      }
     }
   }
 }


### PR DESCRIPTION
Turns out that we never had any tests for what should happen if a stop becomes active during a test.
This PR is trying to design a spec for the `Simulator` interface for what should happen if a stop, assert or assume fires.