### PR TITLE
formal: add a past(..., N) function for assert/assume statements

### DIFF
--- a/src/main/scala/chiseltest/formal/FirrtlUtils.scala
+++ b/src/main/scala/chiseltest/formal/FirrtlUtils.scala
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal
+
+import chisel3.util.log2Ceil
+import firrtl._
+
+/** firrtl utility functions used in our passes.
+  * At some point, these could be moved into the firrtl repo.
+  */
+private object FirrtlUtils {
+  def plusOne(e: ir.Expression): ir.Expression = {
+    val width = e.tpe.asInstanceOf[ir.UIntType].width.asInstanceOf[ir.IntWidth].width
+    val addTpe = ir.UIntType(ir.IntWidth(width + 1))
+    val add = ir.DoPrim(PrimOps.Add, List(e, ir.UIntLiteral(1, ir.IntWidth(width))), List(), addTpe)
+    ir.DoPrim(PrimOps.Bits, List(add), List(width - 1, 0), e.tpe)
+  }
+
+  def findClockAndReset(m: ir.Module): (ir.Reference, ir.Reference) = {
+    val clock = m.ports
+      .find(_.name == "clock")
+      .getOrElse(
+        throw new RuntimeException(s"[${m.name}] Expected module to have a port named clock!")
+      )
+    val reset = m.ports
+      .find(_.name == "reset")
+      .getOrElse(
+        throw new RuntimeException(s"[${m.name}] Expected module to have a port named reset!")
+      )
+    (ir.Reference(clock).copy(flow = SourceFlow), ir.Reference(reset).copy(flow = SourceFlow))
+  }
+
+  /** Creates a register in canonical form from LoFirrtl expressions. */
+  def makeRegister(
+    info:  ir.Info,
+    name:  String,
+    clock: ir.Expression,
+    reset: ir.Expression,
+    next:  Option[ir.Expression],
+    init:  Option[ir.Expression]
+  ): (ir.Reference, ir.DefRegister, ir.Statement) = {
+    require(clock.tpe == ir.ClockType, s"Invalid clock expression: ${clock.serialize} : ${clock.tpe.serialize}")
+    val hasAsyncReset = reset.tpe match {
+      case ir.AsyncResetType => true
+      case ir.UIntType(_)    => false
+      case other             => throw new RuntimeException(s"Invalid reset expression: ${reset.serialize} : ${other.serialize}")
+    }
+    val tpe: ir.Type = (next, init) match {
+      case (None, None) =>
+        throw new RuntimeException("You need to specify at least one, either an init or a next expression!")
+      case (Some(n), None) => n.tpe
+      case (None, Some(i)) => i.tpe
+      case (Some(n), Some(i)) =>
+        require(
+          n.tpe == i.tpe,
+          s"Reset and init expression need to be of the same type, not: ${n.tpe.serialize} vs. ${i.tpe.serialize}"
+        )
+        n.tpe
+    }
+    val sourceRef = ir.Reference(name, tpe, RegKind, SourceFlow)
+    val sinkRef = sourceRef.copy(flow = SinkFlow)
+
+    // we make sure to construct the register as if it was normalized by the RemoveResets pass
+    val (resetExpr, initExpr) = (hasAsyncReset, init) match {
+      case (true, Some(i)) => (reset, i)
+      case _               => (Utils.False(), sourceRef)
+    }
+
+    val reg = ir.DefRegister(info, name, tpe, clock, resetExpr, initExpr)
+    val con = (hasAsyncReset, next, init) match {
+      case (true, None, _)           => ir.EmptyStmt
+      case (true, Some(n), _)        => ir.Connect(info, sinkRef, n)
+      case (false, None, Some(i))    => ir.Connect(info, sinkRef, i)
+      case (false, Some(n), None)    => ir.Connect(info, sinkRef, n)
+      case (false, Some(n), Some(i)) => ir.Connect(info, sinkRef, Utils.mux(reset, i, n))
+      case other                     => throw new RuntimeException(s"Invalid combination! $other")
+    }
+    (sourceRef, reg, con)
+  }
+
+  def makeSaturatingCounter(
+    info:       ir.Info,
+    name:       String,
+    activeName: String,
+    maxValue:   Int,
+    clock:      ir.Expression,
+    reset:      ir.Expression
+  ): (ir.Reference, ir.Reference, Seq[ir.Statement]) = {
+    require(maxValue > 0)
+    val tpe = ir.UIntType(ir.IntWidth(List(1, log2Ceil(maxValue + 1)).max))
+    val init = Utils.getGroundZero(tpe)
+    val ref = ir.Reference(name, tpe, RegKind, SourceFlow)
+    // the counter is active, iff it is less than the maxValue
+    val lessThan = ir.DoPrim(PrimOps.Lt, List(ref, ir.UIntLiteral(maxValue, tpe.width)), List(), Utils.BoolType)
+    val isActiveNode = ir.DefNode(info, activeName, lessThan)
+    val isActive = ir.Reference(isActiveNode).copy(flow = SourceFlow)
+    // increment the counter iff it is active, otherwise just keep the last value
+    val next = Utils.mux(isActive, plusOne(ref), ref)
+    val (_, reg, regNext) = makeRegister(info, name, clock, reset, next = Some(next), init = Some(init))
+    (ref, isActive, Seq(reg, isActiveNode, regNext))
+  }
+}

--- a/src/main/scala/chiseltest/formal/past.scala
+++ b/src/main/scala/chiseltest/formal/past.scala
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal
+
+import chisel3._
+import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
+import chisel3.util.{log2Ceil, ShiftRegisters}
+import chiseltest.formal.FirrtlUtils.findClockAndReset
+import firrtl.annotations._
+import firrtl._
+import firrtl.options.Dependency
+import firrtl.transforms.EnsureNamedStatements
+
+import scala.collection.mutable
+
+/** Delays a signal for verification purposes.
+  * Any stop, assert, assign or cover statement that the result is used in will be automatically guarded
+  * by the time necessary for all past values to become available.
+  * E.g.:
+  * @example {{{
+  *   assert(past(out) === past(past(in)))
+  * }}}
+  * is equivalent to:
+  * @example {{{
+  *   when(cyclesSinceReset >= 2.U) {
+  *     assert(RegNext(out) === RegNext(RegNext(in)))
+  *   }
+  * }}}
+  *
+  * @warn: Currently `Past` is only supported in [[chisel3.Module]] with a single reset or clock domains.
+  *        Please file an issue with a detailed description of your use-case and the intended behavior
+  *        and we will try to add support for you usage of `withReset` or `withClock`.
+  */
+object past {
+  def apply[T <: Data](signal: T, delayBy: Int = 1): T = {
+    require(delayBy >= 0, f"We cannot see into the future!")
+    if (delayBy == 0) {
+      signal
+    } else {
+      // we create a shift register to delay the signal + an annotation to ensure it will be used safely!
+      val out = (0 until delayBy).foldLeft(signal)((p, _) => makeReg(p))
+      // make a wire so that no-one can overwrite the shift register
+      WireInit(out)
+    }
+  }
+
+  private def makeReg[T <: Data](prev: T): T = {
+    val past = RegNext(prev)
+    annotate(new ChiselAnnotation with RunFirrtlTransform {
+      override def transformClass = classOf[SafePastSignalsPass]
+      override def toFirrtl = PastSignalAnnotation(past.toTarget)
+    })
+    past
+  }
+}
+
+object rose {
+
+  /** returns true if the signal was low in the previous cycle and is now high */
+  def apply(signal: Bool): Bool = !past(signal) && signal
+}
+
+object fell {
+
+  /** returns true if the signal was high in the previous cycle and is now low */
+  def apply(signal: Bool): Bool = past(signal) && !signal
+}
+
+object stable {
+
+  /** returns true if the signal was the same in the previous cycle as it is now */
+  def apply(signal: Data): Bool = past(signal).asUInt() === signal.asUInt()
+}
+
+object changed {
+
+  /** returns true if the signal was the different in the previous cycle as it is now */
+  def apply(signal: Data): Bool = past(signal).asUInt() =/= signal.asUInt()
+}
+
+case class PastSignalAnnotation(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
+  override def duplicate(n: ReferenceTarget): PastSignalAnnotation = copy(target = n)
+}
+
+class SafePastSignalsPass extends Transform with DependencyAPIMigration {
+  override def prerequisites =
+    firrtl.stage.Forms.LowForm :+ Dependency(EnsureNamedStatements)
+  override def invalidates(a: Transform) = false
+
+  override def execute(state: CircuitState): CircuitState = {
+    val (pastAnnos, otherAnnos) = state.annotations.partition(_.isInstanceOf[PastSignalAnnotation])
+    if (pastAnnos.isEmpty) return state
+
+    val pastAnnosByModule = pastAnnos.collect {
+      case a @ PastSignalAnnotation(target) if target.circuit == state.circuit.main => target.module -> a
+    }.groupBy(_._1).map { case (k, v) => k -> v.map(_._2) }
+    val circuit = state.circuit.mapModule(m => onModule(m, pastAnnosByModule.getOrElse(m.name, Seq())))
+    state.copy(circuit = circuit, annotations = otherAnnos)
+  }
+
+  private def onModule(dm: ir.DefModule, annos: Seq[PastSignalAnnotation]): ir.DefModule = dm match {
+    case m: ir.Module if annos.nonEmpty =>
+      val isPastReg = annos.map(_.target.ref).toSet
+      // if there are no past registers in this module, there is nothing to do
+      if (isPastReg.isEmpty) return m
+
+      val delays = findPastDelays(m, isPastReg)
+      // if no positive delays were found, there is nothing to do
+      if (delays.isEmpty) {
+        logger.warn(
+          s"[${m.name}] signals delayed with Past(...) aren't used in any assert/assume statements: "
+            + isPastReg.mkString(", ")
+        )
+        return m
+      }
+
+      // create a module level cycle counter
+      val namespace = Namespace(m)
+      val (clock, reset) = findClockAndReset(m)
+      val (counterStmts, delayExpr) = makeCycleCounter(delays.map(_._2), namespace, clock, reset)
+
+      // map delays to guards and add guards to statements
+      val guards = delays.map { case (n, d) => n -> delayExpr(d) }.toMap
+      val bodyWithGuards = m.body.mapStmt(addDelayGuard(m.name, _, guards.get))
+
+      // combine all statements
+      val body = ir.Block(counterStmts :+ bodyWithGuards)
+      m.copy(body = body)
+    case other => other
+  }
+
+  import FirrtlUtils._
+
+  private def addDelayGuard(m: String, s: ir.Statement, guard: String => Option[ir.Expression]): ir.Statement =
+    s match {
+      case v: ir.Verification =>
+        guard(v.name) match {
+          case None => v
+          case Some(g) =>
+            logger.info(
+              s"[$m] ${v.op} statement ${v.name} is disabled until ${g.serialize} cycles after reset. ${v.info.serialize}"
+            )
+            v.withEn(Utils.and(v.en, g))
+        }
+      case other => other.mapStmt(addDelayGuard(m, _, guard))
+    }
+
+  private def makeCycleCounter(
+    delays:    Seq[Int],
+    namespace: Namespace,
+    clock:     ir.Expression,
+    reset:     ir.Expression
+  ): (Seq[ir.Statement], Map[Int, ir.Expression]) = {
+    val maxDelay = delays.max
+    val (count, isActive, countStmts) = makeSaturatingCounter(
+      ir.NoInfo,
+      namespace.newName("_cycles"),
+      namespace.newName("_cycles_active"),
+      maxDelay,
+      clock,
+      reset
+    )
+    val width = count.tpe.asInstanceOf[ir.UIntType].width
+    val stmtsAndRefs = delays.distinct.map { after =>
+      val isAfter = if (after == maxDelay) { Utils.not(isActive) }
+      else {
+        // count >= after
+        ir.DoPrim(PrimOps.Geq, List(count, ir.UIntLiteral(after, width)), List(), Utils.BoolType)
+      }
+      val node = ir.DefNode(ir.NoInfo, namespace.newName(s"_after_$after"), isAfter)
+      (node, (after, ir.Reference(node).copy(flow = SourceFlow)))
+    }
+    (countStmts ++ stmtsAndRefs.map(_._1), stmtsAndRefs.map(_._2).toMap)
+  }
+
+  // determines the number of `past` delays feeding into a verification statement
+  private def findPastDelays(m: ir.Module, isPastReg: String => Boolean): Seq[(String, Int)] = {
+    // determine the names of verification statements + the graph of register dependencies
+    val analysis =
+      AnalysisCtx(mutable.HashMap[String, Set[String]](), mutable.ArrayBuffer[String](), mutable.HashSet[String]())
+    m.foreachStmt(findRegisterInputs(_, analysis))
+
+    analysis.verificationOps
+      .map(name => name -> findPastDelay(name, analysis.inp.get, isPastReg))
+      .filter(_._2 > 0)
+      .toSeq
+  }
+
+  // this function resolves combinatorial read ports
+  private def getFanIn(from: String, inp: String => Option[Set[String]]): Seq[String] = inp(from) match {
+    case None => Seq()
+    case Some(localFanIn) =>
+      val (readPort, reg) = localFanIn.toSeq.partition(_.contains('.'))
+      reg ++ readPort.flatMap(getFanIn(_, inp))
+  }
+
+  private def findPastDelay(from: String, inp: String => Option[Set[String]], isPastReg: String => Boolean): Int = {
+    val localFanIn = getFanIn(from, inp)
+    val pastRegChildren = localFanIn.filter(isPastReg)
+    if (pastRegChildren.isEmpty) { 0 }
+    else { pastRegChildren.map(findPastDelay(_, inp, isPastReg)).max + 1 }
+  }
+
+  private case class AnalysisCtx(
+    inp:             mutable.HashMap[String, Set[String]],
+    verificationOps: mutable.ArrayBuffer[String],
+    combReadMem:     mutable.HashSet[String])
+
+  private def findRegisterInputs(s: ir.Statement, ctx: AnalysisCtx): Unit = s match {
+    case ir.DefNode(_, name, value) => ctx.inp(name) = getRegisters(value, ctx)
+    case w: ir.DefWire => throw new RuntimeException(s"Unexpected wire: $w")
+    case ir.Connect(_, loc, expr) =>
+      loc match {
+        case ir.Reference(name, _, RegKind, _) =>
+          ctx.inp(name) = getRegisters(expr, ctx)
+        case ir.SubField(ir.SubField(ir.Reference(mem, _, MemKind, _), port, _, _), _, _, _)
+            if ctx.combReadMem.contains(mem) =>
+          ctx.inp(s"$mem.$port") = ctx.inp.getOrElse(s"$mem.$port", Set()) | getRegisters(expr, ctx)
+        case _ =>
+        // ignore other connections
+      }
+    case v: ir.Verification =>
+      ctx.verificationOps.append(v.name)
+      ctx.inp(v.name) = Seq(v.pred, v.en).map(getRegisters(_, ctx)).reduce(_ | _)
+    case m: ir.DefMemory if m.readLatency == 0 => ctx.combReadMem.add(m.name)
+    case other => other.foreachStmt(findRegisterInputs(_, ctx))
+  }
+
+  private def getRegisters(e: ir.Expression, ctx: AnalysisCtx): Set[String] = e match {
+    case ir.Reference(name, _, RegKind, _) => Set(name)
+    case ir.Reference(name, _, _, _)       => ctx.inp.getOrElse(name, Set())
+    case ir.SubField(ir.SubField(ir.Reference(mem, _, MemKind, _), port, _, _), field, _, _)
+        if ctx.combReadMem.contains(mem) =>
+      // combinatorial read ports are not necessarily in SSA and need to be resolved at the end of the analysis
+      Set(s"$mem.$port")
+    case _: ir.SubField => Set() // ignoring sub modules
+    case ir.Mux(cond, tval, fval, _) => Seq(cond, tval, fval).map(getRegisters(_, ctx)).reduce(_ | _)
+    case ir.DoPrim(_, args, _, _)    => args.map(getRegisters(_, ctx)).reduce(_ | _)
+    case ir.ValidIf(cond, value, _)  => Seq(cond, value).map(getRegisters(_, ctx)).reduce(_ | _)
+    case _: ir.Literal => Set()
+  }
+
+}

--- a/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
@@ -66,7 +66,6 @@ private class TreadleContext(tester: TreadleTester, toplevel: TopmoduleInfo) ext
       case Some(_) =>
       case None    => throw NoClockException(tester.topName)
     }
-
     try {
       tester.step(n = n)
     } catch {

--- a/src/test/scala/chiseltest/formal/SafePastSpec.scala
+++ b/src/test/scala/chiseltest/formal/SafePastSpec.scala
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal
+
+import chisel3._
+import chisel3.experimental.verification
+import chiseltest._
+import logger.{LogLevel, LogLevelAnnotation}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class PastTestModule(sel: Int) extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+
+  out := RegNext(RegNext(in))
+
+  // all of these should be equivalent!
+  sel match {
+    case 0 => verification.assert(past(past(in)) === out)
+    case 1 => verification.assert(out === past(past(in)))
+    case 2 => verification.assert(past(in, 2) === out)
+  }
+}
+
+class PastWhenTestModule extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+
+  out := RegNext(in, init = 0.U)
+  when(past(in) === 11.U) {
+    verification.assert(out === 11.U)
+  }
+}
+
+class PastMemTestModule extends Module {
+  val addr = IO(Input(UInt(8.W)))
+  val data = IO(Input(UInt(32.W)))
+  val aEn = IO(Input(Bool()))
+  val bEn = IO(Input(Bool()))
+
+  val m = Mem(32, UInt(32.W))
+  // we have two write ports that can collide
+  when(aEn) { m.write(addr, data) }
+  when(bEn) { m.write(addr, data) }
+  // exactly one port is always active
+  verification.assume(aEn ^ bEn)
+
+  // we delay the data manually to make sure the `Past(addr)` is correctly propagated through the combinatorial read port
+  verification.assert(m.read(past(addr)) === RegNext(data))
+}
+
+class SafePastSpec extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  behavior of "Safe Past"
+
+  (0 until 3).foreach { ii =>
+    it should s"guard the assertions appropriately (style=$ii)" taggedAs FormalTag in {
+      verify(new PastTestModule(ii), Seq(BoundedCheck(4)))
+    }
+  }
+
+  it should "guard the assertion appropriately even when past is used in a surrounding when statement" taggedAs FormalTag in {
+    verify(new PastWhenTestModule, Seq(BoundedCheck(4)))
+  }
+
+  it should "correctly propagate delay information through a combinatorial read port" taggedAs FormalTag in {
+    verify(new PastMemTestModule, Seq(BoundedCheck(4)))
+  }
+}

--- a/src/test/scala/chiseltest/formal/examples/DecoupledGCD.scala
+++ b/src/test/scala/chiseltest/formal/examples/DecoupledGCD.scala
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal.examples
+
+import chisel3._
+import chisel3.experimental.verification
+import chiseltest._
+import chiseltest.formal._
+import chiseltest.iotesters.DecoupledGcd
+import org.scalatest.flatspec.AnyFlatSpec
+
+class FormalGcdSpec extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "GCD" should "pass" taggedAs FormalTag in {
+    verify(new DecoupledGcdSpec(new DecoupledGcd(4)), Seq(BoundedCheck(20)))
+  }
+}
+
+/** check formal properties of the DecoupledGcd implementation */
+class DecoupledGcdSpec(makeDut: => DecoupledGcd) extends Module with Observer {
+  // create an instance of our DUT and expose its I/O
+  val dut = Module(makeDut)
+  val input = IO(chiselTypeOf(dut.input))
+  input <> dut.input
+  val output = IO(chiselTypeOf(dut.output))
+  output <> dut.output
+
+  // create a cross module binding to inspect internal state
+  val busy = observe(dut.busy)
+
+  // do not accept new inputs while busy
+  when(busy) {
+    verification.assert(!input.fire())
+  }
+
+  // only release outputs when busy
+  when(output.fire()) {
+    verification.assert(output.fire())
+  }
+
+  // when there was no transactions, busy should not change
+  when(past(!input.fire() && !output.fire())) {
+    verification.assert(stable(busy))
+  }
+
+  // when busy changed from 0 to 1, an input was accepted
+  when(rose(busy)) {
+    verification.assert(past(input.fire()))
+  }
+
+  // when busy changed from 1 to 0, an output was transmitted
+  when(fell(busy)) {
+    verification.assert(past(output.fire()))
+  }
+}

--- a/src/test/scala/chiseltest/formal/examples/KeepMax.scala
+++ b/src/test/scala/chiseltest/formal/examples/KeepMax.scala
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal.examples
+
+import chisel3._
+import chisel3.experimental.verification
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class KeepMaxVerify extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "KeppMax(1)" should "have a monotonically increasing output" taggedAs FormalTag in {
+    verify(new KeepMax(1), Seq(BoundedCheck(4)))
+  }
+
+  "KeppMax(8)" should "have a monotonically increasing output" taggedAs FormalTag in {
+    verify(new KeepMax(8), Seq(BoundedCheck(4)))
+  }
+}
+
+
+/** KeepMax demo by Tom Alcorn
+  * src: https://github.com/tdb-alcorn/chisel-formal/blob/master/src/test/scala/chisel3/formal/SanitySpec.scala
+  */
+class KeepMax(width: Int) extends Module {
+  val in = IO(Input(UInt(width.W)))
+  val out = IO(Output(UInt(width.W)))
+
+  val max = RegInit(0.U(width.W))
+  when (in > max) {
+    max := in
+  }
+  out := max
+
+  // get the value of io.out from 1 cycle in the past
+  verification.assert(out >= past(out))
+}

--- a/src/test/scala/chiseltest/formal/examples/SvaDemos.scala
+++ b/src/test/scala/chiseltest/formal/examples/SvaDemos.scala
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal.examples
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.{ChiselAnnotation, annotate, verification}
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest.formal.FormalTag
+import firrtl.annotations.PresetAnnotation
+
+/** These small examples demonstrate how the chisel Past operator can be used
+  * to emulate simple SVA constructs.
+  * All demos are based on the awesome SVA tutorial from SymbioticEDA:
+  * https://github.com/SymbioticEDA/sva-demos
+  */
+class SvaDemos extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "Demo1" should "fail a bounded check 17 cycles after reset" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new SvaDemo1, Seq(BoundedCheck(20)))
+    }
+    assert(e.failAt == 17)
+  }
+
+  Seq("A" -> (() => new SvaDemo2), "B" -> (() => new SvaDemo2B), "C" -> (() => new SvaDemo2C))
+  .foreach { case (n, gen) =>
+    s"Demo2$n" should "fail a bounded check 15 cycles after reset" taggedAs FormalTag in {
+      val e = intercept[FailedBoundedCheckException] {
+        verify(gen(), Seq(BoundedCheck(20)))
+      }
+      assert(e.failAt == 15)
+    }
+  }
+
+  "Demo3" should "fail a bounded check 16 cycles after reset" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new SvaDemo3, Seq(BoundedCheck(20)))
+    }
+    assert(e.failAt == 16)
+  }
+}
+
+class SvaDemo1 extends SvaDemoModule {
+  seqs(
+    //       01234567890123456789
+    reset = "-_____-____-________",
+    a     = "_--___-___-______-__",
+    b     = "__--__-__________-__",
+  )
+
+  // we can replace the a |=> b with our past operator
+  when(past(a)) { verification.assert(b) }
+}
+
+class SvaDemo2 extends SvaDemoModule {
+  seqs(
+    //       0123456789012345678901
+    reset = "-_____-_______________",
+    a     = "_-____-_______-_______",
+    b     = "___-__-__________-____",
+  )
+
+  // we need to manually express the two different possibilities
+  verification.assert(IfThen(past(a, 2), b) || past(IfThen(past(a), b)))
+}
+
+/** This version changes the trace to test the (allowed) possibility of b going high the cycle after a */
+class SvaDemo2B extends SvaDemoModule {
+  seqs(
+    //       0123456789012345678901
+    reset = "-_____-_______________",
+    a     = "_-____-___-___-_______",
+    b     = "___-__-____-_____-____",
+  )
+
+  // we need to manually express the two different possibilities
+  verification.assert(IfThen(past(a, 2), b) || past(IfThen(past(a), b)))
+}
+
+/** This version shows that b can be high independent from a */
+class SvaDemo2C extends SvaDemoModule {
+  seqs(
+    //       0123456789012345678901
+    reset = "-_____-_______________",
+    a     = "_-____-_______-_______",
+    b     = "---------------__-----",
+  )
+
+  // we need to manually express the two different possibilities
+  // assert property (a |-> ##[1:2] b);
+  verification.assert(IfThen(past(a, 2), b) || past(IfThen(past(a), b)))
+}
+
+class SvaDemo3 extends SvaDemoModule {
+  seqs(
+    //       0123456789012345678901
+    reset = "-_______-___________",
+    a     = "_--___-_______-_____",
+    b     = "__--___-________--__",
+    c     = "____-_____________-_",
+  )
+
+  // we need to manually express the property
+  // note that our translation will fail 2 cycles later than the original
+  // assert property ($rose(a) |=> b[*2] ##1 c);
+  when(past(rose(a), 3)) {
+    verification.assert(past(b, 2) && past(b) && c)
+  }
+}
+
+class SvaDemoModule extends Module {
+  private val preset = IO(Input(AsyncReset()))
+  annotate(new ChiselAnnotation {
+    override def toFirrtl = PresetAnnotation(preset.toTarget)
+  })
+  private def seq(values: String): Bool = {
+    withReset(preset) {
+      require(values.forall(c => c == '_' || c == '-'), s"$values contains invalid characters")
+      val (counter, wrap) = Counter(true.B, values.length + 1)
+      val bools = VecInit(values.map(c => (c == '-').B))
+      bools(counter)
+    }
+  }
+  val (a, b, c) = (WireInit(false.B), WireInit(false.B), WireInit(false.B))
+  def seqs(reset: String, a: String, b: String, c: String = ""): Unit = {
+    seqs_p(reset, a, b, c)
+  }
+  private def seqs_p(rStr: String, aStr: String, bStr: String, cStr: String): Unit = {
+    val r = seq(rStr)
+    withReset(false.B) {
+      verification.assume(reset.asBool() === r)
+    }
+    if(aStr.nonEmpty) a := seq(aStr)
+    if(bStr.nonEmpty) b := seq(bStr)
+    if(cStr.nonEmpty) c := seq(cStr)
+  }
+}
+
+object IfThen {
+  def apply(if_clause: Bool, then_clause: Bool): Bool = !if_clause || then_clause
+}

--- a/src/test/scala/chiseltest/formal/examples/VGBComparisonOfFormalAndSimulation.scala
+++ b/src/test/scala/chiseltest/formal/examples/VGBComparisonOfFormalAndSimulation.scala
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal.examples
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.BundleLiterals._
+import chisel3.experimental._
+import chisel3.util.experimental.BoringUtils
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Chisel port of the "Verification Gentleman" blog post on formal vs. simulation.
+  * src: https://github.com/verification-gentleman-blog/comparison-of-formal-and-simulation
+  * blog: https://blog.verificationgentleman.com/2020/11/comparison-of-formal-and-simulation-part-1.html
+  * */
+class VGBComparisonOfFormalAndSimulation extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "ShapeProcessorProp" should "pass" taggedAs FormalTag in {
+    // note: CVC4 seems to be significantly faster on this example than the default Z3
+    verify(new ShapeProcessorProps, Seq(BoundedCheck(4), CVC4EngineAnnotation))
+  }
+
+  // TODO: unfortunately we currently do not support cover statements
+}
+
+class ShapeProcessorProps extends Module with Observer {
+  import ShapeProcessorModelling._
+  import ShapeEnum._
+  import OperationEnum._
+
+  val io = IO(new ShapeProcessorIO)
+  val dut = Module(new ShapeProcessor)
+  dut.io <> io
+
+  val sfr = observe(dut.ctrlSfr) // make a cross module reference
+  val shapeInSfr = sfr.shape
+  val operationInSfr = sfr.operation
+
+  //------------------------------------------------------------------------------------------------
+  // Check that we never see any reserved values in the SFR. This ensures that the DUT will have
+  // some kind of handling in place to reject such values.
+  verification.assert(!isReservedShape(shapeInSfr))
+  verification.assert(!isReservedOperation(operationInSfr))
+
+  //------------------------------------------------------------------------------------------------
+  // Check that we never see any KEEP_* values in the SFR. This ensures that the DUT will have
+  // some kind of special handling in place for these values.
+  verification.assert(shapeInSfr =/= KeepShape.asUInt())
+  verification.assert(operationInSfr =/= KeepOperation.asUInt())
+
+  //------------------------------------------------------------------------------------------------
+  // Check that we only see legal shape/operation combinations in the SFR. This ensures that the
+  // DUT has some kind of mechanism to block illegal combinations from being written.
+  verification.assert(isLegalCombination(shapeInSfr, operationInSfr))
+
+  //------------------------------------------------------------------------------------------------
+  // Cover that we can see each shape. This way we know that the DUT can, in principle, update the
+  // 'SHAPE' field. Using this property we can flag errors if the design ignores this field
+  // completely when writing.
+  verification.cover(shapeInSfr === Circle.asUInt())
+  verification.cover(shapeInSfr === Rectangle.asUInt())
+  verification.cover(shapeInSfr === Triangle.asUInt())
+
+  //------------------------------------------------------------------------------------------------
+  // Cover that we can see each operation. The same comments as for 'SHAPE' apply.
+  OperationEnum.all.foreach { op =>
+    verification.cover(operationInSfr === op.asUInt())
+  }
+
+  //------------------------------------------------------------------------------------------------
+  val readDataAsCtrlSfr = io.readData.asTypeOf(new CtrlSfrReg)
+  val shapeOnReadBus = readDataAsCtrlSfr.shape
+  val operationOnReadBus = readDataAsCtrlSfr.operation
+
+  //------------------------------------------------------------------------------------------------
+  // Check that the SFR values are delivered as read data at bus reads.
+  verification.assert(IfThen(io.read, shapeOnReadBus === shapeInSfr))
+  verification.assert(IfThen(io.read, operationOnReadBus === operationInSfr))
+
+  //------------------------------------------------------------------------------------------------
+  // Check that only updates the SFR on a bus write. Ensures that there are no sporadic updates
+  // caused by other events.
+  verification.assert(IfThen(past(!io.write), stable(sfr)))
+
+  //------------------------------------------------------------------------------------------------
+  val writeDataAsCtrlSfr = io.writeData.asTypeOf(new CtrlSfrReg)
+  val shapeOnWriteBus = writeDataAsCtrlSfr.shape
+  val operationOnWriteBus = writeDataAsCtrlSfr.operation
+
+  //------------------------------------------------------------------------------------------------
+  // Check that KEEP_* properly keep the values of their corresponding fields. This satisfies the
+  // first part of the requirement for these values.
+  verification.assert(IfThen(
+    past(io.write && shapeOnWriteBus === KeepShape.asUInt()), stable(shapeInSfr)
+  ))
+  verification.assert(IfThen(
+    past(io.write && operationOnWriteBus === KeepOperation.asUInt()), stable(operationInSfr)
+  ))
+
+  //------------------------------------------------------------------------------------------------
+  // Cover that we can see the operation change whenever we write KEEP_SHAPE (and vice-versa). This
+  // way we know that the DUT can, in principle, satisfy the second part of the requirement for
+  // KEEP_* values.
+  verification.cover(past(io.write && shapeOnWriteBus === KeepShape.asUInt()) && changed(operationInSfr))
+  verification.cover(past(io.write && operationOnWriteBus === KeepOperation.asUInt()) && changed(shapeInSfr))
+
+  //------------------------------------------------------------------------------------------------
+  // Check that writes with reserved values are completely ignored. This ensures that the DUT
+  // doesn't treat reserved values as 'KEEP_*' by mistake.
+  verification.assert(IfThen(
+    past(io.write && isReservedShape(shapeOnWriteBus)), stable(sfr)
+  ))
+  verification.assert(IfThen(
+    past(io.write && isReservedOperation(operationOnWriteBus)), stable(sfr)
+  ))
+
+  //------------------------------------------------------------------------------------------------
+  // Check that writes of illegal combinations of proper modes are completely ignored. This ensures
+  // that the DUT doesn't, for example, write some default combination of modes in such cases.
+  verification.assert(IfThen(
+    past(io.write && shapeOnWriteBus === KeepShape.asUInt() &&
+      !isLegalCombination(shapeInSfr, operationOnWriteBus)),
+    stable(sfr)
+  ))
+
+  verification.assert(IfThen(
+    past(io.write && operationOnWriteBus === KeepOperation.asUInt() &&
+      !isLegalCombination(shapeOnWriteBus, operationInSfr)),
+    stable(sfr)
+  ))
+
+
+  //------------------------------------------------------------------------------------------------
+  // Check that legal CTRL writes update the SFR fields.
+  val isLegalCtrlWriteDataCombination: Bool = {
+    val shape = Mux(shapeOnWriteBus === KeepShape.asUInt(), shapeInSfr, shapeOnWriteBus)
+    val operation = Mux(operationOnWriteBus === KeepOperation.asUInt(), operationInSfr, operationOnWriteBus)
+    isLegalCombination(shape, operation)
+  }
+
+  val isLegalCtrlWriteData: Bool =
+    !isReservedShape(shapeOnWriteBus) &&
+      !isReservedOperation(operationOnWriteBus) &&
+      isLegalCtrlWriteDataCombination
+
+  verification.assert(IfThen(
+    past(io.write && isLegalCtrlWriteData && shapeOnWriteBus =/= KeepShape.asUInt()),
+    shapeInSfr === past(shapeOnWriteBus)
+  ))
+
+  verification.assert(IfThen(
+    past(io.write && isLegalCtrlWriteData && operationOnWriteBus =/= KeepOperation.asUInt()),
+    operationInSfr === past(operationOnWriteBus)
+  ))
+
+  //------------------------------------------------------------------------------------------------
+  // Check that illegal CTRL writes don't update the SFR fields. This catches all cases of illegal
+  // writes under one 'assert', instead of having them spread out over many.
+  verification.assert(IfThen(past(io.write && !isLegalCtrlWriteData), stable(sfr)))
+}
+
+trait Observer { this: Module =>
+  protected def observe[T <: Data](signal: T): T = {
+    val wire = WireInit(0.U.asTypeOf(chiselTypeOf(signal)))
+    BoringUtils.bore(signal, Seq(wire))
+    wire
+  }
+}
+
+object ShapeProcessorModelling {
+  import OperationEnum._
+  import ShapeEnum._
+
+  def isReservedShape(value: UInt): Bool = !ShapeEnum.safe(value)._2
+  def isReservedOperation(value: UInt): Bool = !OperationEnum.safe(value)._2
+  def isLegalCombination(shapeUInt: UInt, operationUInt: UInt): Bool = {
+    // nested asserts in chisel do not work the same as they would in SystemVerilog
+    // verification.assert(shape =/= KeepShape)
+    // verification.assert(operation =/= KeepOperation)
+    val ((shape, shapeValid), (operation, opValid)) = (ShapeEnum.safe(shapeUInt), OperationEnum.safe(operationUInt))
+    MuxCase(false.B, Seq(
+      (!(shapeValid && opValid)) -> false.B,
+      operation.isOneOf(Perimeter, Area) -> true.B,
+      (operation === IsSquare) -> (shape === Rectangle),
+      operation.isOneOf(IsEquilateral, IsIsosceles) -> (shape === Triangle),
+    ))
+  }
+}
+
+class CtrlSfrReg extends Bundle {
+  val reserved1 = UInt(13.W)
+  val shape = UInt(3.W)
+  val reserved0 = UInt(9.W)
+  val operation = UInt(7.W)
+}
+
+object ShapeEnum extends ChiselEnum {
+  val Circle    = Value("b001".U(3.W))
+  val Rectangle = Value("b010".U(3.W))
+  val Triangle  = Value("b100".U(3.W))
+  val KeepShape = Value("b111".U(3.W))
+}
+
+object OperationEnum extends ChiselEnum {
+  val Perimeter     = Value("b000_0000".U(7.W))
+  val Area          = Value("b000_0001".U(7.W))
+  val IsSquare      = Value("b010_0000".U(7.W))
+  val IsEquilateral = Value("b100_0000".U(7.W))
+  val IsIsosceles   = Value("b100_0001".U(7.W))
+  val KeepOperation = Value("b111_1111".U(7.W))
+}
+
+class ShapeAndOperation extends Bundle {
+  val shape = UInt(3.W)
+  val operation = UInt(7.W)
+}
+
+
+class ShapeProcessorIO extends Bundle {
+  val write = Input(Bool())
+  val writeData = Input(UInt(32.W))
+  val read = Input(Bool())
+  val readData = Output(UInt(32.W))
+}
+class ShapeProcessor extends Module {
+  val io = IO(new ShapeProcessorIO)
+
+  val ctrlSfr = RegInit((new ShapeAndOperation).Lit(_.shape -> 1.U, _.operation -> 0.U))
+
+  val newShape = Mux(io.writeData(18,16) === Fill(3, 1.U), ctrlSfr.shape, io.writeData(18,16))
+  val newOperation = Mux(io.writeData(6,0) === Fill(7, 1.U), ctrlSfr.operation, io.writeData(6,0))
+
+  when(io.write) {
+    when(isLegalShape(newShape) &&
+      isLegalOperation(newOperation) &&
+      isLegalCombination(newShape, newOperation)) {
+      ctrlSfr.shape := newShape
+      ctrlSfr.operation := newOperation
+    }
+  }
+
+  io.readData := Fill(13, 0.U) ## ctrlSfr.shape ## Fill(9, 0.U) ## ctrlSfr.operation
+
+  def isLegalShape(value: UInt): Bool = {
+    value === 1.U || value === 2.U || value === 4.U
+  }
+  def isLegalOperation(value: UInt): Bool =
+    MuxLookup(value(6,4), false.B, Seq(
+      0.U -> (value(3,0) <= 1.U),
+      2.U -> (value(3,0) === 0.U),
+      4.U -> (value(3,0) <= 1.U),
+    ))
+  def isLegalCombination(shape: UInt, operation: UInt): Bool = {
+    operation(6,4) === 0.U || operation(6,4) === shape
+  }
+}

--- a/src/test/scala/chiseltest/formal/examples/ZipCpuQuizzes.scala
+++ b/src/test/scala/chiseltest/formal/examples/ZipCpuQuizzes.scala
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal.examples
+
+import chisel3.SyncReadMem.{ReadFirst, ReadUnderWrite, Undefined, WriteFirst}
+import chisel3._
+import chisel3.experimental.verification
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Chisel versions of the quizzes from ZipCPU:
+  * http://zipcpu.com/quiz/quizzes.html
+  */
+class ZipCpuQuizzes extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "Quiz1" should "pass with assumption" taggedAs FormalTag in {
+    verify(new Quiz1(true), Seq(BoundedCheck(11)))
+  }
+  "Quiz1" should "fail without assumption" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new Quiz1(false), Seq(BoundedCheck(11)))
+    }
+    assert(e.failAt == 11)
+  }
+
+  "Quiz2" should "fail without counter reset value" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new Quiz2(false), Seq(BoundedCheck(5)))
+    }
+    assert(e.failAt == 0)
+  }
+  "Quiz2" should "pass with counter reset value" taggedAs FormalTag in {
+    verify(new Quiz2(true), Seq(BoundedCheck(5)))
+  }
+
+  "Quiz4" should "fail when using a RegNext to delay the signal" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new Quiz4(0), Seq(BoundedCheck(5)))
+    }
+    assert(e.failAt == 0)
+  }
+  "Quiz4" should "pass when using the Chisel past function" taggedAs FormalTag in {
+    verify(new Quiz4(1), Seq(BoundedCheck(5)))
+  }
+  "Quiz4" should "pass when using the guarded assumption + Chisel past function" taggedAs FormalTag in {
+    verify(new Quiz4(2), Seq(BoundedCheck(5)))
+  }
+
+  "Quiz7" should "fail when using a RegNext to delay the signal" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new Quiz7(false), Seq(BoundedCheck(5)))
+    }
+    assert(e.failAt == 0)
+  }
+  "Quiz7" should "pass when using the Chisel past function" taggedAs FormalTag in {
+    verify(new Quiz7(true), Seq(BoundedCheck(5)))
+  }
+
+  "Quiz13" should "pass when x is 1 wide" taggedAs FormalTag in {
+    verify(new Quiz13(1), Seq(BoundedCheck(4)))
+  }
+  "Quiz13" should "pass when x is 8 wide" taggedAs FormalTag in {
+    verify(new Quiz13(8), Seq(BoundedCheck(4)))
+  }
+
+  "Quiz15" should "fail when using ReadFirst" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new Quiz15(ReadFirst), Seq(BoundedCheck(5)))
+    }
+    assert(e.failAt == 1)
+  }
+  "Quiz15" should "fail when using Undefined" taggedAs FormalTag in {
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new Quiz15(Undefined), Seq(BoundedCheck(5)))
+    }
+    assert(e.failAt == 1)
+  }
+  "Quiz15" should "pass when using WriteFirst" taggedAs FormalTag in {
+    verify(new Quiz15(WriteFirst), Seq(BoundedCheck(5)))
+  }
+}
+
+/** http://zipcpu.com/quiz/2019/08/03/quiz01.html */
+class Quiz1(withAssume: Boolean) extends Module {
+  val counter = RegInit(0.U(16.W))
+  counter := counter + 1.U
+  verification.assert(counter <= 10.U) // reduced from 100 -> 10 to make it fail faster
+  if(withAssume) {
+    verification.assume(counter <= 9.U)
+  }
+}
+
+/** http://zipcpu.com/quiz/2019/08/08/quiz02.html */
+class Quiz2(withInit: Boolean) extends Module {
+  val iStartSignal = IO(Input(Bool()))
+  val oBusy = IO(Output(Bool()))
+  val MaxAmount = 4.U(16.W) // reduced from 22 -> 4 for faster checking
+  val counter = if(withInit) { RegInit(0.U(16.W)) } else { Reg(UInt(16.W)) }
+
+  when(iStartSignal && counter === 0.U) {
+    counter := MaxAmount - 1.U
+  }.elsewhen(counter =/= 0.U) {
+    counter := counter - 1.U
+  }
+  oBusy := counter =/= 0.U
+  verification.assert(counter < MaxAmount)
+}
+
+/** http://zipcpu.com/quiz/2019/08/19/quiz03.html */
+// TODO: re-visit once we support k-induction
+
+/** http://zipcpu.com/quiz/2019/08/24/quiz04.html */
+class Quiz4(style: Int) extends Module {
+  val iStartSignal = IO(Input(Bool()))
+  val counter = RegInit(0.U(16.W))
+  when(iStartSignal && counter === 0.U) {
+    counter := 3.U // reduced from 23 -> 3 for faster checking
+  }.elsewhen(counter =/= 0.U) {
+    counter := counter - 1.U
+  }
+
+  verification.assert(counter < 4.U) // reduced from 24 -> 4
+
+  style match {
+    case 0 => // similar to the original ZipCPU example
+      verification.assume(!iStartSignal)
+      verification.assert(RegNext(counter === 0.U))
+    case 1 => // using chisel past
+      verification.assume(!iStartSignal)
+      verification.assert(past(counter === 0.U))
+    case 2 => // the solution suggested by ZipCPU (implemented with Chisel past)
+      when(past(counter === 0.U && !iStartSignal)) {
+        verification.assert(counter === 0.U)
+      }
+  }
+}
+
+/** https://zipcpu.com/quiz/2019/08/31/quiz05.html */
+// since we do not have SVA style sequence support, this one is hard to make work
+
+/** https://zipcpu.com/quiz/2019/09/06/quiz06.html */
+// chisel is focused on synchronous circuits so we do not support clock events for now
+
+/** https://zipcpu.com/quiz/2019/11/16/quiz07.html */
+class Quiz7(fixed: Boolean) extends Module {
+  val iStartSignal = IO(Input(Bool()))
+  val oBusy = IO(Output(Bool()))
+  val counter = RegInit(0.U(16.W))
+  when(iStartSignal && counter === 0.U) {
+    counter := 3.U // reduced from 21 -> 3 for faster checking
+  }.elsewhen(counter =/= 0.U) {
+    counter := counter - 1.U
+  }
+  oBusy := counter =/= 0.U
+
+  if(fixed) {
+    when(past(iStartSignal) && past(counter === 0.U)) {
+      verification.assert(counter === 3.U) // reduced from 21 -> 3 for faster checking
+    }
+  } else {
+    when(RegNext(iStartSignal)) {
+      verification.assert(counter === 3.U) // reduced from 21 -> 3 for faster checking
+    }
+  }
+}
+
+/** http://zipcpu.com/quiz/2019/11/29/quiz08.html */
+// TODO: consider implementing once we support k-induction
+
+/** http://zipcpu.com/quiz/2019/12/12/quiz09.html */
+// this one is hard to translate to Chisel since we do not have blocking assignment
+
+/** http://zipcpu.com/quiz/2020/01/17/quiz10.html */
+class Quiz10 extends Module {
+  val iStall = IO(Input(Bool()))
+  val oRequest = IO(Output(Bool()))
+  val oRequestDetails = IO(Output(UInt(16.W)))
+
+  // Using the Chisel past function, this example is safe and will automatically be disabled
+  // in the first cycle after reset.
+  when(past(oRequest) && past(iStall)) {
+    verification.assert(oRequest)
+    verification.assert(stable(oRequestDetails))
+  }
+}
+
+/** http://zipcpu.com/quiz/2020/01/23/quiz11.html */
+// TODO: consider implementing once we support k-induction
+
+/** http://zipcpu.com/quiz/2020/09/14/quiz13.html */
+class Quiz13(xWidth: Int) extends Module {
+  require(xWidth > 0)
+  val x = IO(Input(UInt(xWidth.W)))
+
+  verification.assert(stable(x) === (x === past(x)))
+  verification.assert(changed(x) === (x =/= past(x)))
+  // Chisel's rose function only operates on Bool, not on UInt of arbitrary sizes!
+  // => thus we cannot (easily) make the same mistake as in the original question
+  verification.assert(rose(x(0)) === (x(0) && !past(x(0))))
+  verification.assert(fell(x(0)) === (!x(0) && past(x(0))))
+}
+
+/** http://zipcpu.com/quiz/2020/12/24/quiz14.html */
+// TODO: consider implementing once we have good multi-clock support
+
+/** http://zipcpu.com/quiz/2021/06/12/quiz15.html */
+class Quiz15(readUnderWrite: ReadUnderWrite) extends Module {
+  val iWrite = IO(Input(Bool()))
+  val iData = IO(Input(UInt(32.W)))
+  val iWAddr = IO(Input(UInt(8.W)))
+  val iRead = IO(Input(Bool()))
+  val iRAddr = IO(Input(UInt(8.W)))
+  val oData = IO(Output(UInt(32.W)))
+
+  val mem = SyncReadMem(256, chiselTypeOf(iData), readUnderWrite)
+  when(iWrite) { mem.write(iWAddr, iData) }
+  oData := mem.read(iRAddr, iRead)
+
+  // This will only pass if we chose the write first behavior.
+  // Read first will return an old value and undefined will result in an
+  // arbitrary value to be read (the write is still performed and available
+  // a cycle later).
+  when(past(iWrite && iRead && iWAddr === iRAddr)) {
+    verification.assert(oData === past(iData))
+  }
+}
+
+/** https://zipcpu.com/quiz/2021/07/10/quiz16.html */
+// TODO: consider implementing once we have good async reset support
+
+/** https://zipcpu.com/quiz/2021/08/05/quiz17.html */
+// TODO: consider implementing once we support k-induction


### PR DESCRIPTION
This allows users to write assertions/assumptions about past values without having to manually keep track of whether they are valid or not. An automated analysis pass figures out the maximum `Past` delay and delays the assertion for the right amount of cycles after reset.