### PR TITLE
formal: implement our own smt solver bindings + checker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,6 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "edu.berkeley.cs" %% "chisel3"       % defaultVersions("chisel3"),
   "edu.berkeley.cs" %% "treadle"       % defaultVersions("treadle"),
-  "edu.berkeley.cs" %% "maltese-smt"   % "0.5-SNAPSHOT",
   "org.scalatest"   %% "scalatest"     % "3.1.4",
   "com.lihaoyi"     %% "utest"         % "0.7.9",
   "net.java.dev.jna" % "jna" % "5.9.0",

--- a/build.sc
+++ b/build.sc
@@ -11,7 +11,6 @@ object chiseltest extends mill.Cross[chiseltestCrossModule]("2.12.13")
 val defaultVersions = Map(
   "chisel3" -> "3.5-SNAPSHOT",
   "treadle" -> "1.5-SNAPSHOT",
-  "maltese-smt" -> "0.5-SNAPSHOT",
 )
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
@@ -38,12 +37,6 @@ class chiseltestCrossModule(val crossScalaVersion: String) extends CrossSbtModul
     getVersion("treadle")
   ) else Agg.empty[Dep]
 
-  def malteseModule: Option[PublishModule] = None
-
-  def malteseIvyDeps = if (treadleModule.isEmpty) Agg(
-    getVersion("maltese-smt")
-  ) else Agg.empty[Dep]
-
   override def millSourcePath = super.millSourcePath / os.up
 
   // 2.12.12 -> Array("2", "12", "12") -> "12" -> 12
@@ -63,14 +56,14 @@ class chiseltestCrossModule(val crossScalaVersion: String) extends CrossSbtModul
     super.javacOptions() ++ Seq("-source", "1.8", "-target", "1.8")
   }
 
-  override def moduleDeps = super.moduleDeps ++ chisel3Module ++ treadleModule ++ malteseModule
+  override def moduleDeps = super.moduleDeps ++ chisel3Module ++ treadleModule
 
   override def ivyDeps = T {
     Agg(
       ivy"org.scalatest::scalatest:3.1.4",
       ivy"com.lihaoyi::utest:0.7.9",
       ivy"net.java.dev.jna:jna:5.9.0",
-    ) ++ chisel3IvyDeps ++ treadleIvyDeps ++ malteseIvyDeps
+    ) ++ chisel3IvyDeps ++ treadleIvyDeps
   }
 
   object test extends Tests with ScalafmtModule {

--- a/src/main/scala/chiseltest/formal/backends/IsModelChecker.scala
+++ b/src/main/scala/chiseltest/formal/backends/IsModelChecker.scala
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+package chiseltest.formal.backends
+
+import firrtl.backends.experimental.smt._
+
+private[chiseltest] trait ModelCheckResult {
+  def isFail: Boolean
+  def isSuccess: Boolean = !isFail
+}
+private[chiseltest] case class ModelCheckSuccess() extends ModelCheckResult { override def isFail: Boolean = false }
+private[chiseltest] case class ModelCheckFail(witness: Witness) extends ModelCheckResult {
+  override def isFail: Boolean = true
+}
+
+private[chiseltest] trait IsModelChecker {
+  def name: String
+  val prefix:        String
+  val fileExtension: String
+  def check(sys: TransitionSystem, kMax: Int = -1, fileName: Option[String] = None): ModelCheckResult
+}
+
+private[chiseltest] case class Witness(
+  failed:  Seq[String],
+  regInit: Map[Int, BigInt],
+  memInit: Map[Int, Seq[(Option[BigInt], BigInt)]],
+  inputs:  Seq[Map[Int, BigInt]])

--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -2,14 +2,14 @@
 
 package chiseltest.formal.backends
 
+import chiseltest.formal.backends.smt._
 import chiseltest.formal.{DoNotModelUndef, FailedBoundedCheckException}
 import firrtl._
 import firrtl.annotations._
-import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlStage, RunFirrtlTransformAnnotation}
-import maltese.mc._
-import maltese.smt.solvers._
-import chiseltest.simulator.{Compiler, TreadleBackendAnnotation, WriteVcdAnnotation}
-import firrtl.backends.experimental.smt.random.{InvalidToRandomPass, UndefinedMemoryBehaviorPass}
+import firrtl.stage._
+import firrtl.backends.experimental.smt.random._
+import firrtl.backends.experimental.smt._
+import chiseltest.simulator._
 import firrtl.options.Dependency
 
 sealed trait FormalEngineAnnotation extends NoTargetAnnotation
@@ -95,7 +95,7 @@ private[chiseltest] object Maltese {
     )
     val stateMap = FlattenPass.getStateMap(circuit.main, res)
     val memDepths = FlattenPass.getMemoryDepths(circuit.main, res)
-    val sys = firrtl.backends.experimental.smt.ExpressionConverter.toMaltese(res).get
+    val sys = res.collectFirst { case TransitionSystemAnnotation(s) => s }.get
 
     // print the system, convenient for debugging, might disable once we have done more testing
     if (true) {
@@ -114,7 +114,7 @@ private[chiseltest] object Maltese {
     engines.map {
       case CVC4EngineAnnotation   => new SMTModelChecker(new CVC4SMTLib)
       case Z3EngineAnnotation     => new SMTModelChecker(new Z3SMTLib)
-      case BtormcEngineAnnotation => new BtormcModelChecker
+      case BtormcEngineAnnotation => throw new NotImplementedError("btor2 backends are not yet supported!")
     }
   }
 

--- a/src/main/scala/chiseltest/formal/backends/TransitionSystemSimulator.scala
+++ b/src/main/scala/chiseltest/formal/backends/TransitionSystemSimulator.scala
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+package chiseltest.formal.backends
+
+import treadle.vcd
+import chiseltest.formal.backends.smt._
+import firrtl.backends.experimental.smt._
+
+import scala.collection.mutable
+
+private[chiseltest] class TransitionSystemSimulator(
+  sys:               TransitionSystem,
+  val maxMemVcdSize: Int = 128,
+  printUpdates:      Boolean = false) {
+  private val (bvStates, arrayStates) = sys.states.partition(s => s.sym.isInstanceOf[BVSymbol])
+  private val (bvSignals, arraySignals) = sys.signals.partition(s => s.e.isInstanceOf[BVExpr])
+
+  //
+  private val allArrays = (arrayStates.map(_.sym) ++ arraySignals.map(_.sym)).map(_.asInstanceOf[ArraySymbol])
+  private val allBV = (sys.inputs ++ bvStates.map(_.sym) ++ bvSignals.map(_.sym)).map(_.asInstanceOf[BVSymbol])
+
+  // mutable state indexing
+  private val bvNameToIndex = allBV.map(_.name).zipWithIndex.toMap
+  private val arrayNameToIndex = allArrays.map(_.name).zipWithIndex.toMap
+
+  // mutable state
+  private val data = new Array[BigInt](bvNameToIndex.size)
+  private val memories = new Array[Memory](arrayNameToIndex.size)
+
+  // quantifier variables
+  private val varData = new mutable.HashMap[String, BigInt]()
+
+  // vcd dumping
+  private var vcdWriter: Option[vcd.VCD] = None
+  private val observedMemories =
+    arrayStates.map(_.sym.asInstanceOf[ArraySymbol]).filter(a => arrayDepth(a.indexWidth) <= maxMemVcdSize)
+
+  private case class Memory(data: IndexedSeq[BigInt]) extends ArrayValue {
+    def depth: Int = data.size
+    def write(index: Option[BigInt], value: BigInt): Memory = {
+      index match {
+        case None => Memory(IndexedSeq.fill(depth)(value))
+        case Some(ii) =>
+          assert(ii >= 0 && ii < depth, s"index ($ii) needs to be non-negative smaller than the depth ($depth)!")
+          Memory(data.updated(ii.toInt, value))
+      }
+    }
+    def read(index: BigInt): BigInt = {
+      assert(index >= 0 && index < depth, s"index ($index) needs to be non-negative smaller than the depth ($depth)!")
+      data(index.toInt)
+    }
+    def ==(other: ArrayValue): Boolean = {
+      assert(other.isInstanceOf[Memory])
+      other.asInstanceOf[Memory].data == this.data
+    }
+  }
+  private def randomBits(bits: Int): BigInt = BigInt(bits, scala.util.Random)
+  private def randomSeq(depth: Int, bits: Int): IndexedSeq[BigInt] = (0 to depth).map(_ => randomBits(bits))
+
+  private def writesToMemory(depth: Int, bits: Int, writes: Iterable[(Option[BigInt], BigInt)]): Memory =
+    writes.foldLeft(Memory(randomSeq(depth, bits))) { case (mem, (index, value)) => mem.write(index, value) }
+
+  private val evalCtx: SMTEvalCtx = new SMTEvalCtx {
+    override def getBVSymbol(name: String): BigInt = {
+      val value = bvNameToIndex.get(name) match {
+        case Some(index) => data(index)
+        case None        => varData(name)
+      }
+      assert(value != null, s"Trying to read uninitialized symbol $name!")
+      value
+    }
+
+    override def getArraySymbol(name: String): Memory = memories(arrayNameToIndex(name))
+
+    override def startVariableScope(name: String, value: BigInt): Unit = {
+      assert(!varData.contains(name))
+      varData(name) = value
+    }
+    override def endVariableScope(name: String): Unit = {
+      varData.remove(name)
+    }
+
+    override def constArray(indexWidth: Int, value: BigInt): Memory = {
+      Memory(IndexedSeq.fill(arrayDepth(indexWidth))(value))
+    }
+  }
+
+  private val CheckWidths = true
+  private def eval(expr: BVExpr): BigInt = {
+    val value = SMTExprEval.eval(expr)(evalCtx)
+    if (CheckWidths) {
+      val mask = (BigInt(1) << expr.width) - 1
+      if ((value & mask) != value) {
+        throw new RuntimeException(s"Failed to evaluate $expr!\nvalue $value does not fit into ${expr.width} bits!")
+      }
+    }
+    value
+  }
+  private def evalArray(expr: ArrayExpr): Memory = SMTExprEval.evalArray(expr)(evalCtx).asInstanceOf[Memory]
+
+  private def arrayDepth(indexWidth: Int): Int = (BigInt(1) << indexWidth).toInt
+
+  private def init(
+    regInit: Map[Int, BigInt],
+    memInit: Map[Int, Seq[(Option[BigInt], BigInt)]],
+    withVcd: Boolean
+  ): Unit = {
+    // initialize vcd
+    vcdWriter =
+      if (!withVcd) None
+      else {
+        val vv = vcd.VCD(sys.name)
+        vv.addWire("Step", 64)
+        allBV.foreach(s => vv.addWire(s.name, s.width))
+        observedMemories.foreach { m =>
+          val depth = arrayDepth(m.indexWidth)
+          (0 to depth).foreach(a => vv.addWire(s"${m.name}.$a", m.dataWidth))
+        }
+        Some(vv)
+      }
+
+    // initialize registers and memories in order (this ensures that they are topologically sorted by their init dependencies)
+    sys.states.zipWithIndex.foreach { case (state, ii) =>
+      if (arrayNameToIndex.contains(state.name)) {
+        // init memory
+        val value = state.init match {
+          case Some(init) => evalArray(init.asInstanceOf[ArrayExpr])
+          case None =>
+            val sym = state.sym.asInstanceOf[ArraySymbol]
+            val depth = arrayDepth(sym.indexWidth)
+            val bits = sym.dataWidth
+            if (memInit.contains(ii)) {
+              writesToMemory(depth, bits, memInit(ii))
+            } else {
+              Memory(randomSeq(depth, bits))
+            }
+        }
+        memories(arrayNameToIndex(state.name)) = value
+      } else {
+        // init register
+        val value = state.init match {
+          case Some(init) => eval(init.asInstanceOf[BVExpr])
+          case None =>
+            regInit.get(ii) match {
+              case Some(value) => value
+              case None =>
+                randomBits(state.sym.asInstanceOf[BVSymbol].width)
+            }
+        }
+        data(bvNameToIndex(state.name)) = value
+      }
+    }
+  }
+
+  private def step(index: Int, inputs: Map[Int, BigInt], expectedFailed: Option[Seq[String]] = None): Unit = {
+    vcdWriter.foreach(_.wireChanged("Step", index))
+
+    if (printUpdates) println(s"\nSTEP $index")
+
+    // dump state
+    vcdWriter.foreach { v =>
+      bvStates.foreach { state => v.wireChanged(state.name, data(bvNameToIndex(state.name))) }
+      observedMemories.foreach { mem =>
+        val depth = arrayDepth(mem.indexWidth)
+        val array = memories(arrayNameToIndex(mem.name))
+        (0 until depth).foreach(a => v.wireChanged(s"${mem.name}.$a", array.read(a)))
+      }
+    }
+
+    // apply inputs
+    sys.inputs.zipWithIndex.foreach { case (input, ii) =>
+      val value = inputs(ii)
+      data(ii) = value
+      vcdWriter.foreach(_.wireChanged(input.name, value))
+      if (printUpdates) println(s"I: ${input.name} <- $value")
+    }
+
+    // evaluate signals
+    sys.signals.foreach {
+      case Signal(name, e: BVExpr, _) =>
+        val value = eval(e)
+        if (printUpdates) println(s"S: $name -> $value")
+        data(bvNameToIndex(name)) = value
+        vcdWriter.foreach(_.wireChanged(name, value))
+      case Signal(name, e: ArrayExpr, _) =>
+        val value = evalArray(e)
+        memories(arrayNameToIndex(name)) = value
+    }
+
+    // calculate next states
+    val newBVState = bvStates.map { state =>
+      val value = state.next match {
+        case Some(next) => eval(next.asInstanceOf[BVExpr])
+        case None       => throw new NotImplementedError(s"State $state without a next function is not supported")
+      }
+      (state.name, value)
+    }.toVector
+
+    val newArrayState = arrayStates.map { state =>
+      val value = state.next match {
+        case Some(next) => evalArray(next.asInstanceOf[ArrayExpr])
+        case None       => throw new NotImplementedError(s"State $state without a next function is not supported")
+      }
+      (state.name, value)
+    }.toVector
+
+    // make sure constraints are not violated
+    def simpl(e: SMTExpr): SMTExpr = e // no simplification for now
+    sys.signals.filter(_.lbl == IsConstraint).foreach { signal =>
+      val holds = data(bvNameToIndex(signal.name))
+      assert(holds == 0 || holds == 1, s"Constraint ${signal.name} returned invalid value when evaluated: $holds")
+      if (holds == 0) {
+        println(s"ERROR: Constraint #${signal.name} was violated!")
+      }
+    }
+
+    // check to see if any safety properties failed
+    val failed = sys.signals
+      .filter(_.lbl == IsBad)
+      .map { signal =>
+        (signal.name, data(bvNameToIndex(signal.name)))
+      }
+      .filter(_._2 != 0)
+      .map(_._1)
+    def failedMsg(name: String): String = {
+      val expr = simpl(sys.signals.find(_.name == name).get.e)
+      //val syms = symbolsToString(Context.findSymbols(expr)).mkString(", ")
+      s"$name: $expr"
+    }
+    def failedPropertiesMsg: String =
+      s"Failed (${failed.size}) properties in step #$index:\n${failed.map(failedMsg).mkString("\n")}"
+    expectedFailed match {
+      case None =>
+        assert(failed.isEmpty, "Unexpected failure!! " + failedPropertiesMsg)
+      case Some(Seq()) => // this means that we do not know which exact property is supposed to fail
+      case Some(props) =>
+        val failedSet = failed.toSet
+        if (!props.toSet.subsetOf(failedSet)) {
+          println(
+            s"In step #$index: Expected properties ${props.mkString(", ")} to fail, instead ${failed.mkString(", ")} failed"
+          )
+        }
+    }
+
+    // increment time
+    vcdWriter.foreach(_.incrementTime())
+
+    // update state
+    newBVState.foreach { case (name, value) =>
+      if (printUpdates) println(s"R: $name <- $value")
+      data(bvNameToIndex(name)) = value
+    }
+    newArrayState.foreach { case (name, value) => memories(arrayNameToIndex(name)) = value }
+  }
+
+  def run(witness: Witness, vcdFileName: Option[String] = None): Unit = {
+    init(witness.regInit, witness.memInit, withVcd = vcdFileName.nonEmpty)
+    witness.inputs.zipWithIndex.foreach { case (inputs, index) =>
+      // on the last step we expect the bad states to be entered
+      if (index == witness.inputs.size - 1) {
+        step(index, inputs, Some(witness.failed))
+      } else {
+        step(index, inputs)
+      }
+    }
+    vcdFileName.foreach { ff =>
+      val vv = vcdWriter.get
+      vv.wireChanged("Step", witness.inputs.size)
+      vv.incrementTime()
+      vv.write(ff)
+    }
+  }
+}

--- a/src/main/scala/chiseltest/formal/backends/smt/SMTExprEval.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/SMTExprEval.scala
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+
+package chiseltest.formal.backends.smt
+
+import firrtl.backends.experimental.smt._
+
+import scala.annotation.tailrec
+
+private[chiseltest] trait SMTEvalCtx {
+  def getBVSymbol(name:        String): BigInt
+  def getArraySymbol(name:     String): ArrayValue
+  def startVariableScope(name: String, value: BigInt): Unit
+  def endVariableScope(name:   String): Unit
+  def constArray(indexWidth:   Int, value: BigInt): ArrayValue
+}
+
+private[chiseltest] trait ArrayValue {
+  def ==(other:    ArrayValue): Boolean
+  def read(index:  BigInt): BigInt
+  def write(index: Option[BigInt], value: BigInt): ArrayValue
+}
+
+private[chiseltest] object SMTExprEval {
+
+  def eval(expr: BVExpr)(implicit ctx: SMTEvalCtx): BigInt = {
+    val value = expr match {
+      case BVLiteral(value, _)            => value
+      case BVSymbol(name, _)              => ctx.getBVSymbol(name)
+      case BVExtend(e, by, signed)        => doBVExtend(eval(e), e.width, by, signed)
+      case BVSlice(e, hi, lo)             => doBVSlice(eval(e), hi, lo)
+      case BVNot(e)                       => doBVNot(eval(e), e.width)
+      case BVNegate(e)                    => doBVNegate(eval(e), e.width)
+      case BVImplies(a, b)                => doBVNot(eval(a), 1) | eval(b)
+      case BVEqual(a, b)                  => doBVEqual(eval(a), eval(b))
+      case BVComparison(op, a, b, signed) => doBVCompare(op, eval(a), eval(b), a.width, signed)
+      case BVOp(op, a, b)                 => doBVOp(op, eval(a), eval(b), a.width)
+      case BVConcat(a, b)                 => doBVConcat(eval(a), eval(b), bWidth = b.width)
+      case ArrayRead(array, index)        => evalArray(array).read(eval(index))
+      case BVIte(cond, tru, fals) =>
+        val c = eval(cond)
+        assert(c == 0 || c == 1)
+        if (c == 1) { eval(tru) }
+        else { eval(fals) }
+      case ArrayEqual(a, b) => if (evalArray(a) == evalArray(b)) BigInt(1) else BigInt(0)
+      case BVReduceOr(e)    => bool(eval(e) != 0)
+      case BVReduceAnd(e) =>
+        val mask = (BigInt(1) << e.width) - 1
+        bool(eval(e) == mask)
+      case BVReduceXor(e) =>
+        val r = eval(e)
+        assert(r >= 0, "bit vectors should always be positive!")
+        bool(r.bitCount % 2 == 1)
+      case BVAnd(terms) => bool(terms.forall(eval(_) != 0))
+      case BVOr(terms)  => bool(terms.exists(eval(_) != 0))
+      case BVForall(variable, e) =>
+        val maxValue = (BigInt(1) << variable.width) - 1
+        if (maxValue > 4096) {
+          throw new NotImplementedError(
+            s"TODO: deal with forall of large ranges in witness simulator: $variable has ${variable.width} bits!"
+          )
+        }
+        val res = (0 to maxValue.toInt).iterator.forall { value =>
+          ctx.startVariableScope(variable.name, value)
+          // evaluate expression
+          val isTrue = eval(e) == 1
+          ctx.endVariableScope(variable.name)
+          isTrue
+        }
+        if (res) BigInt(1) else BigInt(0)
+      case _: BVFunctionCall => throw new NotImplementedError("function call")
+    }
+    value
+  }
+
+  def evalArray(expr: ArrayExpr)(implicit ctx: SMTEvalCtx): ArrayValue = expr match {
+    case s: ArraySymbol => ctx.getArraySymbol(s.name)
+    case ArrayConstant(e, indexWidth) =>
+      ctx.constArray(indexWidth, eval(e))
+    case ArrayStore(array, index, data) =>
+      evalArray(array).write(Some(eval(index)), eval(data))
+    case ArrayIte(cond, tru, fals) =>
+      val c = eval(cond)
+      assert(c == 0 || c == 1)
+      if (c == 1) { evalArray(tru) }
+      else { evalArray(fals) }
+    case other => throw new RuntimeException(s"Unsupported array expression $other")
+  }
+
+  private def doBVExtend(e: BigInt, width: Int, by: Int, signed: Boolean): BigInt = {
+    if (signed && isNegative(e, width)) {
+      (mask(by) << width) | e
+    } else { e }
+  }
+  private def doBVSlice(e:  BigInt, hi:    Int, lo: Int): BigInt = (e >> lo) & mask(hi - lo + 1)
+  private def doBVNot(e:    BigInt, width: Int): BigInt = flipBits(e, width)
+  private def doBVNegate(e: BigInt, width: Int):    BigInt = sub(0, e, width)
+  private def doBVEqual(a:  BigInt, b:     BigInt): BigInt = bool(a == b)
+  @tailrec
+  private def doBVCompare(op: Compare.Value, a: BigInt, b: BigInt, width: Int, signed: Boolean): BigInt = {
+    if (a == b && op == Compare.GreaterEqual) return bool(true)
+
+    // only checking for Greater than
+    if (signed) {
+      (isPositive(a, width), isPositive(b, width)) match {
+        case (true, true)  => doBVCompare(op, a, b, width - 1, signed = false)
+        case (true, false) =>
+          // a < 0 && b >= 0 => a can never be greater or equal to b
+          bool(false)
+        case (false, true) =>
+          // a >= 0 && b < 0 => a is greater than b
+          bool(true)
+        case (false, false) => doBVCompare(op, doBVNegate(b, width), doBVNegate(a, width), width - 1, signed = false)
+      }
+    } else {
+      bool(a > b)
+    }
+
+  }
+  private def doBVOp(op: Op.Value, a: BigInt, b: BigInt, width: Int): BigInt = op match {
+    case Op.Xor       => a ^ b
+    case Op.ShiftLeft => (a << b.toInt) & mask(width)
+    case Op.ArithmeticShiftRight =>
+      val by = b.toInt
+      if (isPositive(a, width)) { a >> by }
+      else if (by >= width) { mask(width) }
+      else {
+        val msb = mask(by) << (width - by)
+        (a >> by) | msb
+      }
+    case Op.ShiftRight => a >> b.toInt
+    case Op.Add        => (a + b) & mask(width)
+    case Op.Mul        => (a * b) & mask(width)
+    case Op.Sub        => sub(a, b, width)
+    case other         => throw new NotImplementedError(other.toString)
+  }
+  private def doBVConcat(a: BigInt, b: BigInt, bWidth: Int): BigInt = (a << bWidth) | b
+
+  // helper functions
+  private def sub(a:            BigInt, b: BigInt, width: Int): BigInt = (a + flipBits(b, width) + 1) & mask(width)
+  private def mask(width:       Int): BigInt = (BigInt(1) << width) - 1
+  private def isPositive(value: BigInt, w: Int) = (value & mask(w - 1)) == value
+  private def isNegative(value: BigInt, w: Int) = !isPositive(value, w)
+  private def flipBits(value:   BigInt, w: Int) = ~value & mask(w)
+  private def bool(b:           Boolean): BigInt = if (b) BigInt(1) else BigInt(0)
+}
+
+private[chiseltest] case class LocalEvalCtx(bv: Map[String, BigInt], array: Map[String, ArrayValue] = Map())
+    extends SMTEvalCtx {
+  override def getBVSymbol(name: String): BigInt = bv.getOrElse(
+    name, {
+      variables.find(_._1 == name).map(_._2).getOrElse(throw new RuntimeException(s"Unknown symbol $name!"))
+    }
+  )
+  override def getArraySymbol(name: String): ArrayValue = array(name)
+
+  private val variables = scala.collection.mutable.Stack[(String, BigInt)]()
+  override def startVariableScope(name: String, value: BigInt): Unit = {
+    variables.push((name, value))
+  }
+  override def endVariableScope(name: String): Unit = {
+    val old = variables.pop()
+    assert(old._1 == name)
+  }
+  override def constArray(indexWidth: Int, value: BigInt) = ???
+}

--- a/src/main/scala/chiseltest/formal/backends/smt/SMTLibResponseParser.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/SMTLibResponseParser.scala
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+
+package chiseltest.formal.backends.smt
+
+import scala.annotation.tailrec
+
+private object SMTLibResponseParser {
+  def parseValue(v: String): Option[BigInt] = parseValue(SExprParser.parse(v))
+
+  @tailrec
+  private def parseValue(e: SExpr): Option[BigInt] = e match {
+    case SExprNode(List(SExprNode(List(_, SExprLeaf(valueStr))))) => parseBVLiteral(valueStr)
+    // example: (_ bv0 32)
+    case SExprNode(List(SExprNode(List(_, SExprNode(List(SExprLeaf("_"), SExprLeaf(value), SExprLeaf(width)))))))
+        if value.startsWith("bv") =>
+      Some(BigInt(value.drop(2)))
+    case SExprNode(List(one)) => parseValue(one)
+    case _                    => throw new NotImplementedError(s"Unexpected response: $e")
+  }
+
+  type MemInit = Seq[(Option[BigInt], BigInt)]
+
+  def parseMemValue(v: String): MemInit = {
+    val tree = SExprParser.parse(v)
+    tree match {
+      case SExprNode(List(SExprNode(List(_, value)))) => parseMem(value, Map())
+      case _                                          => throw new NotImplementedError(s"Unexpected response: $v")
+    }
+  }
+
+  private def parseMem(value: SExpr, ctx: Map[String, MemInit]): MemInit = value match {
+    case SExprNode(List(SExprNode(List(SExprLeaf("as"), SExprLeaf("const"), tpe)), SExprLeaf(valueStr))) =>
+      // initialize complete memory to value
+      List((None, parseBVLiteral(valueStr).get))
+    case SExprNode(List(SExprLeaf("store"), array, SExprLeaf(indexStr), SExprLeaf(valueStr))) =>
+      val (index, value) = (parseBVLiteral(indexStr), parseBVLiteral(valueStr))
+      parseMem(array, ctx) :+ (Some(index.get), value.get)
+    case SExprNode(List(SExprLeaf("let"), SExprNode(List(SExprNode(List(SExprLeaf(variable), array0)))), array1)) =>
+      val newCtx = ctx ++ Seq(variable -> parseMem(array0, ctx))
+      parseMem(array1, newCtx)
+    case SExprLeaf(variable) =>
+      assert(ctx.contains(variable), s"Undefined variable: $variable. " + ctx.keys.mkString(", "))
+      ctx(variable)
+    case SExprNode(
+          List(
+            SExprLeaf("lambda"),
+            SExprNode(List(SExprNode(List(SExprLeaf(v0), indexTpe)))),
+            SExprNode(List(SExprLeaf("="), SExprLeaf(v1), SExprLeaf(indexStr)))
+          )
+        ) if v0 == v1 =>
+      // example: (lambda ((x!1 (_ BitVec 5))) (= x!1 #b00000))
+      List((None, BigInt(0)), (Some(parseBVLiteral(indexStr).get), BigInt(1)))
+    case other => throw new NotImplementedError(s"TODO implement parsing of SMT solver response: $other")
+  }
+
+  private def parseBVLiteral(valueStr: String): Option[BigInt] = {
+    if (valueStr == "true") { Some(BigInt(1)) }
+    else if (valueStr == "false") { Some(BigInt(0)) }
+    else if (valueStr == "???") { None }
+    else if (valueStr.startsWith("#b")) { Some(BigInt(valueStr.drop(2), 2)) }
+    else if (valueStr.startsWith("#x")) { Some(BigInt(valueStr.drop(2), 16)) }
+    else {
+      throw new NotImplementedError(s"Unsupported number format: $valueStr")
+    }
+  }
+}
+
+sealed trait SExpr
+case class SExprNode(children: List[SExpr]) extends SExpr {
+  override def toString = children.mkString("(", " ", ")")
+}
+case class SExprLeaf(value: String) extends SExpr {
+  override def toString = value
+}
+
+/** simple S-Expression parser to make sense of SMTLib solver output */
+object SExprParser {
+  def parse(line: String): SExpr = {
+    val tokens = line
+      .replace("(", " ( ")
+      .replace(")", " ) ")
+      .split("\\s+")
+      .filterNot(_.isEmpty)
+      .toList
+
+    assert(tokens.nonEmpty)
+    if (tokens.head == "(") {
+      parseSExpr(tokens.tail)._1
+    } else {
+      assert(tokens.tail.isEmpty)
+      SExprLeaf(tokens.head)
+    }
+  }
+
+  private def parseSExpr(tokens: List[String]): (SExpr, List[String]) = {
+    var t = tokens
+    var elements = List[SExpr]()
+    while (t.nonEmpty) {
+      t.head match {
+        case "(" =>
+          val (child, nt) = parseSExpr(t.tail)
+          t = nt
+          elements = elements :+ child
+        case ")" =>
+          return (SExprNode(elements), t.tail)
+        case other =>
+          elements = elements :+ SExprLeaf(other)
+          t = t.tail
+      }
+    }
+    (SExprNode(elements), List())
+  }
+}

--- a/src/main/scala/chiseltest/formal/backends/smt/SMTLibSolver.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/SMTLibSolver.scala
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+
+package chiseltest.formal.backends.smt
+
+import firrtl.backends.experimental.smt._
+
+class Yices2SMTLib extends SMTLibSolver(List("yices-smt2", "--incremental")) {
+  override def name = "yices2-smtlib"
+  override def supportsConstArrays = false
+  override def supportsUninterpretedFunctions = true
+  override def supportsQuantifiers = false
+}
+
+class CVC4SMTLib extends SMTLibSolver(List("cvc4", "--incremental", "--produce-models", "--lang", "smt2")) {
+  override def name = "cvc4-smtlib"
+  override def supportsConstArrays = true
+  override def supportsUninterpretedFunctions = true
+  override def supportsQuantifiers = true
+}
+
+class Z3SMTLib extends SMTLibSolver(List("z3", "-in")) {
+  override def name = "z3-smtlib"
+  override def supportsConstArrays = true
+  override def supportsUninterpretedFunctions = true
+  override def supportsQuantifiers = true
+
+  // Z3 only supports array (as const ...) when the logic is set to ALL
+  override protected def doSetLogic(logic: String): Unit = getLogic match {
+    case None    => writeCommand("(set-logic ALL)")
+    case Some(_) => // ignore
+  }
+}
+
+/** provides basic facilities to interact with any SMT solver that supports a SMTLib base textual interface */
+abstract class SMTLibSolver(cmd: List[String]) extends Solver {
+  protected val debug: Boolean = false
+
+  private var _stackDepth: Int = 0
+  override def stackDepth: Int = _stackDepth
+  override def push(): Unit = {
+    writeCommand("(push 1)")
+    _stackDepth += 1
+  }
+  override def pop(): Unit = {
+    require(_stackDepth > 0)
+    writeCommand("(pop 1)")
+    _stackDepth -= 1
+  }
+  override def assert(expr: BVExpr): Unit = {
+    writeCommand(s"(assert ${serialize(expr)})")
+  }
+  override def queryModel(e: BVSymbol): Option[BigInt] = getValue(e)
+  override def getValue(e: BVExpr): Option[BigInt] = {
+    val cmd = s"(get-value (${serialize(e)}))"
+    writeCommand(cmd)
+    readResponse() match {
+      case Some(strModel) => SMTLibResponseParser.parseValue(strModel.trim)
+      case None           => throw new RuntimeException(s"Solver $name did not reply to $cmd")
+    }
+  }
+  override def getValue(e: ArrayExpr): Seq[(Option[BigInt], BigInt)] = {
+    val cmd = s"(get-value (${serialize(e)}))"
+    writeCommand(cmd)
+    readResponse() match {
+      case Some(strModel) => SMTLibResponseParser.parseMemValue(strModel.trim)
+      case None           => throw new RuntimeException(s"Solver $name did not reply to $cmd")
+    }
+  }
+  override def runCommand(cmd: SMTCommand): Unit = cmd match {
+    case Comment(_)      => // ignore comments
+    case SetLogic(logic) => setLogic(logic)
+    case c: DefineFunction             => writeCommand(serialize(c))
+    case c: DeclareFunction            => writeCommand(serialize(c))
+    case c: DeclareUninterpretedSort   => writeCommand(serialize(c))
+    case c: DeclareUninterpretedSymbol => writeCommand(serialize(c))
+  }
+
+  /** releases all native resources */
+  override def close(): Unit = {
+    writeCommand("(exit)")
+    proc.stdin.flush()
+    Thread.sleep(5)
+    proc.destroyForcibly()
+  }
+  override protected def doSetLogic(logic: String): Unit = getLogic match {
+    case None      => writeCommand(serialize(SetLogic(logic)))
+    case Some(old) => require(logic == old, s"Cannot change logic from $old to $logic")
+  }
+  override protected def doCheck(produceModel: Boolean): SolverResult = {
+    writeCommand("(check-sat)")
+    readResponse() match {
+      case Some(res) =>
+        res.stripLineEnd match {
+          case "sat"   => IsSat
+          case "unsat" => IsUnSat
+          case other   => throw new RuntimeException(s"Unexpected result from SMT solver: $other")
+        }
+      case None =>
+        throw new RuntimeException("Unexpected EOF result from SMT solver.")
+    }
+  }
+
+  private def serialize(e: SMTExpr):    String = SMTLibSerializer.serialize(e)
+  private def serialize(c: SMTCommand): String = SMTLibSerializer.serialize(c)
+
+  private val proc = os.proc(cmd).spawn()
+  protected def writeCommand(str: String): Unit = {
+    if (debug) println(s"$str")
+    proc.stdin.write(str + "\n")
+  }
+  private def readResponse(): Option[String] = {
+    proc.stdin.flush() // make sure the commands reached the solver
+    if (!proc.isAlive()) {
+      None
+    } else {
+      // our basic assumptions are:
+      // 1. the solver will terminate its answer with '\n'
+      // 2. the answer will contain a balanced number of parenthesis
+      var r = proc.stdout.readLine()
+      while (countParens(r) > 0) {
+        r = r + " " + proc.stdout.readLine()
+      }
+      if (debug) println(s"$r")
+      Some(r)
+    }
+  }
+  private def countParens(s: String): Int = s.foldLeft(0) {
+    case (count, '(') => count + 1
+    case (count, ')') => count - 1
+    case (count, _)   => count
+  }
+}

--- a/src/main/scala/chiseltest/formal/backends/smt/SMTModelChecker.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/SMTModelChecker.scala
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+
+package chiseltest.formal.backends.smt
+
+import chiseltest.formal.backends._
+import firrtl.backends.experimental.smt._
+
+import scala.collection.mutable
+
+case class SMTModelCheckerOptions(checkConstraints: Boolean, checkBadStatesIndividually: Boolean)
+object SMTModelCheckerOptions {
+  val Default: SMTModelCheckerOptions =
+    SMTModelCheckerOptions(checkConstraints = true, checkBadStatesIndividually = true)
+  val Performance: SMTModelCheckerOptions =
+    SMTModelCheckerOptions(checkConstraints = false, checkBadStatesIndividually = false)
+}
+
+/** SMT based bounded model checking as an alternative to dispatching to a btor2 based external solver */
+class SMTModelChecker(
+  val solver:    Solver,
+  options:       SMTModelCheckerOptions = SMTModelCheckerOptions.Performance,
+  printProgress: Boolean = false)
+    extends IsModelChecker {
+  override val name:          String = "SMTModelChecker with " + solver.name
+  override val prefix:        String = solver.name
+  override val fileExtension: String = ".smt2"
+
+  override def check(sys: TransitionSystem, kMax: Int, fileName: Option[String] = None): ModelCheckResult = {
+    require(kMax > 0 && kMax <= 2000, s"unreasonable kMax=$kMax")
+    if (fileName.nonEmpty) println("WARN: dumping to file is not supported at the moment.")
+
+    val logic = if (solver.name == "z3") { "ALL" }
+    else { "QF_AUFBV" }
+    solver.setLogic(logic)
+
+    // create new context
+    solver.push()
+
+    // declare/define functions and encode the transition system
+    val enc = new CompactEncoding(sys)
+    enc.defineHeader(solver)
+    enc.init(solver)
+
+    val constraints = sys.signals.filter(_.lbl == IsConstraint).map(_.name)
+    val assertions = sys.signals.filter(_.lbl == IsBad).map(_.name)
+
+    (0 to kMax).foreach { k =>
+      if (printProgress) println(s"Step #$k")
+
+      // assume all constraints hold in this step
+      constraints.foreach(c => solver.assert(enc.getConstraint(c)))
+
+      // make sure the constraints are not contradictory
+      if (options.checkConstraints) {
+        val res = solver.check(produceModel = false)
+        assert(res.isSat, s"Found unsatisfiable constraints in cycle $k")
+      }
+
+      if (options.checkBadStatesIndividually) {
+        // check each bad state individually
+        assertions.zipWithIndex.foreach { case (b, bi) =>
+          if (printProgress) print(s"- b$bi? ")
+
+          solver.push()
+          solver.assert(BVNot(enc.getAssertion(b)))
+          val res = solver.check(produceModel = false)
+
+          // did we find an assignment for which the bad state is true?
+          if (res.isSat) {
+            if (printProgress) println("❌")
+            val w = getWitness(sys, enc, k, Seq(b))
+            solver.pop()
+            solver.pop()
+            assert(solver.stackDepth == 0, s"Expected solver stack to be empty, not: ${solver.stackDepth}")
+            return ModelCheckFail(w)
+          } else {
+            if (printProgress) println("✅")
+          }
+          solver.pop()
+        }
+      } else {
+        val anyBad = BVNot(BVAnd(assertions.map(enc.getAssertion)))
+        solver.push()
+        solver.assert(anyBad)
+        val res = solver.check(produceModel = false)
+
+        // did we find an assignment for which at least one bad state is true?
+        if (res.isSat) {
+          val w = getWitness(sys, enc, k)
+          solver.pop()
+          solver.pop()
+          assert(solver.stackDepth == 0, s"Expected solver stack to be empty, not: ${solver.stackDepth}")
+          return ModelCheckFail(w)
+        }
+        solver.pop()
+      }
+
+      // advance
+      enc.unroll(solver)
+    }
+
+    // clean up
+    solver.pop()
+    assert(solver.stackDepth == 0, s"Expected solver stack to be empty, not: ${solver.stackDepth}")
+    ModelCheckSuccess()
+  }
+
+  private def getWitness(
+    sys:             TransitionSystem,
+    enc:             CompactEncoding,
+    kMax:            Int,
+    failedAssertion: Seq[String] = Seq()
+  ): Witness = {
+    // btor2 numbers states in the order that they are declared in starting at zero
+    val stateInit = sys.states.zipWithIndex.map {
+      case (State(sym: BVSymbol, _, _), ii) =>
+        solver.getValue(enc.getSignalAt(sym, 0)) match {
+          case Some(value) => (Some(ii -> value), None)
+          case None        => (None, None)
+        }
+      case (State(sym: ArraySymbol, _, _), ii) =>
+        val value = solver.getValue(enc.getSignalAt(sym, 0))
+        (None, Some(ii -> value))
+    }
+
+    val regInit = stateInit.flatMap(_._1).toMap
+    val memInit = stateInit.flatMap(_._2).toMap
+
+    val inputs = (0 to kMax).map { k =>
+      sys.inputs.zipWithIndex.flatMap { case (input, i) =>
+        solver.getValue(enc.getSignalAt(input, k)).map(value => i -> value)
+      }.toMap
+    }
+
+    Witness(failedAssertion, regInit, memInit, inputs)
+  }
+
+}
+
+class CompactEncoding(sys: TransitionSystem) {
+  import SMTTransitionSystemEncoder._
+  private def id(s: String): String = SMTLibSerializer.escapeIdentifier(s)
+  private val stateType = id(sys.name + "_s")
+  private val stateInitFun = id(sys.name + "_i")
+  private val stateTransitionFun = id(sys.name + "_t")
+
+  private val states = mutable.ArrayBuffer[UTSymbol]()
+
+  def defineHeader(solver: Solver): Unit = encode(sys).foreach(solver.runCommand)
+
+  private def appendState(solver: Solver): UTSymbol = {
+    val s = UTSymbol(s"s${states.length}", stateType)
+    solver.runCommand(DeclareUninterpretedSymbol(s.name, s.tpe))
+    states.append(s)
+    s
+  }
+
+  def init(solver: Solver): Unit = {
+    assert(states.isEmpty)
+    val s0 = appendState(solver)
+    solver.assert(BVFunctionCall(stateInitFun, List(s0), 1))
+  }
+
+  def unroll(solver: Solver): Unit = {
+    assert(states.nonEmpty)
+    appendState(solver)
+    val tStates = states.takeRight(2).toList
+    solver.assert(BVFunctionCall(stateTransitionFun, tStates, 1))
+  }
+
+  /** returns an expression representing the constraint in the current state */
+  def getConstraint(name: String): BVExpr = {
+    assert(states.nonEmpty)
+    val foo = id(name + "_f")
+    BVFunctionCall(foo, List(states.last), 1)
+  }
+
+  /** returns an expression representing the assertion in the current state */
+  def getAssertion(name: String): BVExpr = {
+    assert(states.nonEmpty)
+    val foo = id(name + "_f")
+    BVFunctionCall(foo, List(states.last), 1)
+  }
+
+  def getSignalAt(sym: BVSymbol, k: Int): BVExpr = {
+    assert(states.length > k, s"no state s$k")
+    val state = states(k)
+    val foo = id(sym.name + "_f")
+    BVFunctionCall(foo, List(state), sym.width)
+  }
+
+  def getSignalAt(sym: ArraySymbol, k: Int): ArrayExpr = {
+    assert(states.length > k, s"no state s$k")
+    val state = states(k)
+    val foo = id(sym.name + "_f")
+    ArrayFunctionCall(foo, List(state), sym.indexWidth, sym.dataWidth)
+  }
+}

--- a/src/main/scala/chiseltest/formal/backends/smt/Solver.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/Solver.scala
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+package chiseltest.formal.backends.smt
+
+import firrtl.backends.experimental.smt._
+
+private[chiseltest] trait Solver {
+  // basic properties
+  def name:                String
+  def supportsQuantifiers: Boolean
+
+  /** Constant Arrays are not required by SMTLib: https://rise4fun.com/z3/tutorialcontent/guide */
+  def supportsConstArrays:            Boolean
+  def supportsUninterpretedFunctions: Boolean
+
+  // basic API
+  def setLogic(logic: String): Unit = {
+    val quantifierFree = logic.startsWith("QF_")
+    require(supportsQuantifiers || quantifierFree, s"$name does not support quantifiers!")
+    val ufs = logic.contains("UF")
+    require(supportsUninterpretedFunctions || !ufs, s"$name does not support uninterpreted functions!")
+    doSetLogic(logic)
+    pLogic = Some(logic)
+  }
+  def getLogic: Option[String] = pLogic
+  def stackDepth: Int // returns the size of the push/pop stack
+  def push():     Unit
+  def pop():      Unit
+  def assert(expr: BVExpr): Unit
+  final def check(produceModel: Boolean): SolverResult = {
+    require(pLogic.isDefined, "Use `setLogic` to select the logic.")
+    pCheckCount += 1
+    doCheck(produceModel)
+  }
+  def runCommand(cmd: SMTCommand): Unit
+  def queryModel(e:   BVSymbol):   Option[BigInt]
+  def getValue(e:     BVExpr):     Option[BigInt]
+  def getValue(e:     ArrayExpr):  Seq[(Option[BigInt], BigInt)]
+
+  /** releases all native resources */
+  def close(): Unit
+
+  // convenience API
+  def check(): SolverResult = check(true)
+  def check(expr: BVExpr): SolverResult = check(expr, produceModel = true)
+  def check(expr: BVExpr, produceModel: Boolean): SolverResult = {
+    push()
+    assert(expr)
+    val res = check(produceModel)
+    pop()
+    res
+  }
+
+  // statistics
+  def checkCount: Int = pCheckCount
+  private var pCheckCount = 0
+
+  // internal functions that need to be implemented by the solver
+  private var pLogic: Option[String] = None
+  protected def doSetLogic(logic:     String):  Unit
+  protected def doCheck(produceModel: Boolean): SolverResult
+}
+
+private[chiseltest] sealed trait SolverResult {
+  def isSat:   Boolean = false
+  def isUnSat: Boolean = false
+}
+private[chiseltest] case object IsSat extends SolverResult { override def isSat = true }
+private[chiseltest] case object IsUnSat extends SolverResult { override def isUnSat = true }
+private[chiseltest] case object IsUnknown extends SolverResult

--- a/src/test/scala/chiseltest/formal/backends/smt/SMTLibResponseParserSpec.scala
+++ b/src/test/scala/chiseltest/formal/backends/smt/SMTLibResponseParserSpec.scala
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.formal.backends.smt
+
+import chiseltest.formal.FormalTag
+import org.scalatest.flatspec.AnyFlatSpec
+
+class SMTLibResponseParserSpec extends AnyFlatSpec {
+  behavior.of("SMTLibResponseParser")
+
+  def in(value: String): String = s"((in $value))"
+
+  it should "parse an array with default value in binary" taggedAs FormalTag in {
+    val array = "((as const (Array (_ BitVec 5) (_ BitVec 32))) #b00000000000000000000000000110011)"
+    val expected = Seq((None, BigInt(0x33)))
+    assert(SMTLibResponseParser.parseMemValue(in(array)) == expected)
+  }
+
+  private val base = "((as const (Array (_ BitVec 5) (_ BitVec 32))) #x00000033)"
+
+  it should "parse an array with default value in hex" taggedAs FormalTag in {
+    val expected = Seq((None, BigInt(0x33)))
+    assert(SMTLibResponseParser.parseMemValue(in(base)) == expected)
+  }
+
+  private val store = s"(store $base #b01110 #x00000000)"
+
+  it should "parse a store" taggedAs FormalTag in {
+    val expected = Seq((None, BigInt(0x33)), (Some(BigInt(0xe)), BigInt(0)))
+    assert(SMTLibResponseParser.parseMemValue(in(store)) == expected)
+  }
+
+  it should "parse a two stores" taggedAs FormalTag in {
+    val store2 = s"(store $store #b01110 #x00000011)"
+    val expected = Seq((None, BigInt(0x33)), (Some(BigInt(0xe)), BigInt(0)), (Some(BigInt(0xe)), BigInt(0x11)))
+    assert(SMTLibResponseParser.parseMemValue(in(store2)) == expected)
+  }
+
+  // Z3 uses lets when doing multiple stores
+  it should "parse a let" taggedAs FormalTag in {
+    val innerStore = s"(store a!1 #b01110 #x00000011)"
+    val letA1 = s"(let ((a!1 $store)) $innerStore)"
+    val expected = Seq((None, BigInt(0x33)), (Some(BigInt(0xe)), BigInt(0)), (Some(BigInt(0xe)), BigInt(0x11)))
+    assert(SMTLibResponseParser.parseMemValue(in(letA1)) == expected)
+  }
+
+  it should "parse a simple lambda" taggedAs FormalTag in {
+    val array = "(lambda ((x!1 (_ BitVec 5))) (= x!1 #b00000))"
+    val expected = Seq((None, BigInt(0)), (Some(BigInt(0)), BigInt(1)))
+    assert(SMTLibResponseParser.parseMemValue(in(array)) == expected)
+  }
+
+  it should "parse a value represented as (_ bv0 32)" taggedAs FormalTag in {
+    def z3Answer(v: Int) = s"(((count_f s0) (_ bv$v 32)))"
+    assert(SMTLibResponseParser.parseValue(z3Answer(0)).get == 0)
+    assert(SMTLibResponseParser.parseValue(z3Answer(1234567)).get == 1234567)
+  }
+
+}

--- a/src/test/scala/chiseltest/formal/backends/smt/Z3SolverSpec.scala
+++ b/src/test/scala/chiseltest/formal/backends/smt/Z3SolverSpec.scala
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.formal.backends.smt
+
+import chiseltest.formal.FormalTag
+import org.scalatest.flatspec.AnyFlatSpec
+import firrtl.backends.experimental.smt._
+
+class Z3SolverSpec extends AnyFlatSpec {
+
+  private def makeSolver() = new Z3SMTLib
+
+  // simple sanity check of the SMTLib based interface to z3
+  it should "check a small bitvector example" taggedAs FormalTag in {
+    val (a, b) = (BVSymbol("a", 8), BVSymbol("b", 8))
+    val a_gt_b = BVComparison(Compare.Greater, a, b, signed = false)
+    val a_lt_2 = BVNot(BVComparison(Compare.GreaterEqual, a, BVLiteral(2, 8), signed = false))
+    val b_gt_2 = BVComparison(Compare.Greater, b, BVLiteral(2, 8), signed = false)
+
+    val solver = makeSolver()
+    solver.setLogic("QF_BV")
+    solver.runCommand(DeclareFunction(a, Seq()))
+    solver.runCommand(DeclareFunction(b, Seq()))
+
+    // assert a > b and a < 2 and b > 2 --> UNSAT
+    solver.assert(a_gt_b)
+    solver.assert(a_lt_2)
+
+    solver.push()
+    solver.assert(b_gt_2)
+    assert(solver.check(produceModel = false).isUnSat)
+    solver.pop()
+
+    // the above is equivalent to
+    assert(solver.check(b_gt_2, produceModel = false).isUnSat)
+
+    // assert a > b and a < 2 --> SAT
+    assert(solver.check(produceModel = true).isSat)
+
+    // get the model
+    val a_value = solver.queryModel(a).get
+    val b_value = solver.queryModel(b).get
+
+    assert(a_value < 2)
+    assert(a_value > b_value)
+
+    solver.close()
+  }
+}


### PR DESCRIPTION
Together with an overhaul of the smt expression library in firrtl, this lets us get rid of the dependency on maltese-smt.

This PR depends on: https://github.com/chipsalliance/firrtl/pull/2350