### PR TITLE
internal: add PrintPeekPoke annotation for debugging

### DIFF
--- a/src/main/scala/chiseltest/internal/Testers2.scala
+++ b/src/main/scala/chiseltest/internal/Testers2.scala
@@ -10,6 +10,9 @@ import scala.util.DynamicVariable
 
 case object CachingAnnotation extends NoTargetAnnotation
 
+/** use this option to have all simulator interactions printed to stdout */
+case object PrintPeekPoke extends NoTargetAnnotation
+
 object Context {
   class Instance(val backend: BackendInterface, val env: TestEnvInterface) {}
 

--- a/src/main/scala/chiseltest/simulator/DebugPrintWrapper.scala
+++ b/src/main/scala/chiseltest/simulator/DebugPrintWrapper.scala
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.simulator
+
+/** Wraps a [[SimulatorContext]] and prints the result of all operations performed on
+  * it to stdout
+  */
+class DebugPrintWrapper(inner: SimulatorContext) extends SimulatorContext {
+  private var cycle: Long = 0
+  override def sim = inner.sim
+  override def step(n: Int): Unit = {
+    val start = cycle
+    cycle += n
+    inner.step(n)
+    println(s"step $start -> $cycle")
+  }
+  override def peek(signal: String) = {
+    val res = inner.peek(signal)
+    println(s"$signal -> $res")
+    res
+  }
+  override def poke(signal: String, value: BigInt): Unit = {
+    inner.poke(signal, value)
+    println(s"$signal <- $value")
+  }
+  override def peekMemory(signal: String, index: Long) = {
+    val res = inner.peekMemory(signal, index)
+    println(s"$signal[$index] -> $res")
+    res
+  }
+
+  override def pokeMemory(signal: String, index: Long, value: BigInt): Unit = {
+    inner.pokeMemory(signal, index, value)
+    println(s"$signal[$index] <- $value")
+  }
+  override def finish(): Unit = {
+    inner.finish()
+    println("finish()")
+  }
+  override def resetCoverage(): Unit = {
+    inner.resetCoverage()
+    println("resetCoverage()")
+  }
+  override def getCoverage() = {
+    val res = inner.getCoverage()
+    println("getCoverage()")
+    res
+  }
+}

--- a/src/test/scala/chiseltest/internal/PrintPeekPokeTest.scala
+++ b/src/test/scala/chiseltest/internal/PrintPeekPokeTest.scala
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiseltest.internal
+
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class PrintPeekPokeTest extends AnyFlatSpec with ChiselScalatestTester {
+  behavior of "PrintPeekPoke"
+
+  it should "print test interactions to stdout" in {
+    val (_, out) = utils.CaptureStdout {
+      test(new tests.PassthroughModule(UInt(8.W))).withAnnotations(Seq(PrintPeekPoke)) { c =>
+        c.in.poke(123.U)
+        c.out.expect(123.U)
+        c.clock.step()
+      }
+    }
+
+    val lines = out.split('\n')
+
+    assert(lines.contains("reset <- 1"))
+    assert(lines.contains("step 0 -> 1"))
+    assert(lines.contains("in <- 123"))
+    assert(lines.contains("out -> 123"))
+    assert(lines.contains("finish()"))
+  }
+
+  it should "only print when the annotation is provided" in {
+    val (_, out) = utils.CaptureStdout {
+      test(new tests.PassthroughModule(UInt(8.W))) { c =>
+        c.in.poke(123.U)
+        c.out.expect(123.U)
+        c.clock.step()
+      }
+    }
+
+    assert(out.trim.isEmpty)
+  }
+}


### PR DESCRIPTION
Some convenient functionality that I recently used to track down a bug. Might come in handy to others and it is part of the `internal` package, so it won't increase our public API surface.