### PR TITLE
formal: split Solver into Solver/SolverContext

### DIFF
--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -112,8 +112,8 @@ private[chiseltest] object Maltese {
     val engines = annos.collect { case a: FormalEngineAnnotation => a }
     assert(engines.nonEmpty, "You need to provide at least one formal engine annotation!")
     engines.map {
-      case CVC4EngineAnnotation   => new SMTModelChecker(new CVC4SMTLib)
-      case Z3EngineAnnotation     => new SMTModelChecker(new Z3SMTLib)
+      case CVC4EngineAnnotation   => new SMTModelChecker(CVC4SMTLib)
+      case Z3EngineAnnotation     => new SMTModelChecker(Z3SMTLib)
       case BtormcEngineAnnotation => throw new NotImplementedError("btor2 backends are not yet supported!")
     }
   }

--- a/src/main/scala/chiseltest/formal/backends/smt/Solver.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/Solver.scala
@@ -13,12 +13,18 @@ private[chiseltest] trait Solver {
   def supportsConstArrays:            Boolean
   def supportsUninterpretedFunctions: Boolean
 
+  def createContext(): SolverContext
+}
+
+private[chiseltest] trait SolverContext {
+  def solver: Solver
+
   // basic API
   def setLogic(logic: String): Unit = {
     val quantifierFree = logic.startsWith("QF_")
-    require(supportsQuantifiers || quantifierFree, s"$name does not support quantifiers!")
+    require(solver.supportsQuantifiers || quantifierFree, s"${solver.name} does not support quantifiers!")
     val ufs = logic.contains("UF")
-    require(supportsUninterpretedFunctions || !ufs, s"$name does not support uninterpreted functions!")
+    require(solver.supportsUninterpretedFunctions || !ufs, s"${solver.name} does not support uninterpreted functions!")
     doSetLogic(logic)
     pLogic = Some(logic)
   }

--- a/src/test/scala/chiseltest/formal/backends/smt/Z3SolverSpec.scala
+++ b/src/test/scala/chiseltest/formal/backends/smt/Z3SolverSpec.scala
@@ -7,7 +7,7 @@ import firrtl.backends.experimental.smt._
 
 class Z3SolverSpec extends AnyFlatSpec {
 
-  private def makeSolver() = new Z3SMTLib
+  private def makeSolver() = Z3SMTLib.createContext()
 
   // simple sanity check of the SMTLib based interface to z3
   it should "check a small bitvector example" taggedAs FormalTag in {


### PR DESCRIPTION
This is similar to the Simulator/SimulatorContext split and allows us to properly terminate solvers running in the background at the end of a model checking run.

Fixes #392 