### PR TITLE
Remove final step from generic backend main loop.

### DIFF
--- a/src/main/scala/chiseltest/internal/GenericBackend.scala
+++ b/src/main/scala/chiseltest/internal/GenericBackend.scala
@@ -4,7 +4,7 @@ package chiseltest.internal
 
 import chiseltest.{ClockResolutionException, Region, TimeoutException}
 import chisel3._
-import chiseltest.coverage.{Coverage, TestCoverage}
+import chiseltest.coverage.TestCoverage
 import chiseltest.simulator.SimulatorContext
 import firrtl.AnnotationSeq
 
@@ -147,7 +147,7 @@ class GenericBackend[T <: Module](
     val mainThread = new TesterThread(
       () => {
         tester.poke("reset", 1)
-        tester.step(1)
+        tester.step()
         tester.poke("reset", 0)
 
         testFn(dut)
@@ -191,7 +191,9 @@ class GenericBackend[T <: Module](
           }
         }
 
-        tester.step(1)
+        if (!mainThread.done) {
+          tester.step()
+        }
       }
     } finally {
       rootTimescope = None

--- a/src/test/scala/chiseltest/coverage/SimulatorCoverageTest.scala
+++ b/src/test/scala/chiseltest/coverage/SimulatorCoverageTest.scala
@@ -27,7 +27,7 @@ abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation,
     assert(cov.keys.toList == List("SIM"))
 
     // since we executed one step and all inputs are zero by default, we expect the count to be 3
-    assert(cov("SIM") == 2)
+    assert(cov("SIM") == 1)
   }
 
   it should "report count for all user cover points (with submodules)" taggedAs tag in {
@@ -40,7 +40,7 @@ abstract class SimulatorCoverageTest(name: String, backend: SimulatorAnnotation,
     assert(cov.keys.toList.sorted == List("SIM", "c0.SIM", "c1.SIM"))
 
     // since we executed one step and all inputs are zero by default, we expect the count to be 3
-    assert(cov("SIM") == 2)
+    assert(cov("SIM") == 1)
     assert(cov("c0.SIM") == 0)
     assert(cov("c1.SIM") == 0)
   }

--- a/src/test/scala/chiseltest/experimental/tests/AssertTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/AssertTest.scala
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.experimental.tests
+
+import chisel3._
+import chisel3.tester._
+import org.scalatest.freespec.AnyFreeSpec
+
+class AssertFail extends Module {
+  val io = IO(new Bundle {
+    val input = Input(UInt(2.W))
+  })
+
+  assert(io.input === 3.U) // This should not be triggered
+}
+
+/*
+Prior to this fix this test would fail because
+the GenericBackend would reset the inputs to their initial values
+and then call a final step and the assert would fire.
+Generic backend no longer calls the final step
+ */
+class AssertTest extends AnyFreeSpec with ChiselScalatestTester {
+  "Internally test resets input but it should not call a final step, as that incorrectly triggers the assert" in {
+    test(new AssertFail).withAnnotations(Seq()) { dut =>
+      dut.io.input.poke(3.U)
+      dut.clock.step()
+    }
+  }
+}


### PR DESCRIPTION
Fixes problem where assert fires due to exiting of default timescope
Fixed couple of nits to make code clean.