### PR TITLE
Add Observer trait and function for Boringtools submodule drilling

### DIFF
--- a/src/main/scala/chiseltest/experimental/Observe.scala
+++ b/src/main/scala/chiseltest/experimental/Observe.scala
@@ -55,7 +55,7 @@ object expose {
     * import chiseltest.experimental._
     *
     * // Here we create a wrapper extending the Top module adding the exposed signals
-    * class TopWrapper extends Top with Observer {
+    * class TopWrapper extends Top {
     *   // Expose the submodule "reg" Register
     *   val exposed_reg  = expose(submodule.reg)
     * }

--- a/src/main/scala/chiseltest/experimental/Observe.scala
+++ b/src/main/scala/chiseltest/experimental/Observe.scala
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.experimental
+
+import chisel3._
+import chisel3.util.experimental._
+
+/** Add this trait to your wrapper module to observe on submodule signals using the `observe` method. This avoids
+  * cluttering the original module with signals that would be used only by the test harness.
+  */
+trait Observer { this: Module =>
+
+  /** The method `observe` allows one to bring to the wrapped module (top), signals from instantiated sub-modules so
+    * they can be tested by peek/poke chiseltest.
+    *
+    * Usage:
+    *
+    * {{{
+    * import chiseltest.experimental.Observer
+    *
+    * // This is the module to be tested
+    * class SubModule extends Module {
+    *     val reg  = Reg(UInt(6.W))
+    *     reg := 42.U
+    *   }
+    *
+    *   // Top module which instantiates the submodule
+    *   class Top extends Module {
+    *     val submodule = Module(new SubModule)
+    *   }
+    *
+    *   // Here we create a wrapper extending the Top module adding the observer
+    *   class TopWrapper extends Top with Observer {
+    *     val observed_reg  = observe(submodule.reg)
+    *   }
+    *
+    * }}}
+    *
+    * The `Top` module can be tested with `chiseltest` and `scalatest` like:
+    * {{{
+    *   it should "observe a submodule Reg by using BoringUtils" in {
+    *     test(new TopWrapper) { c =>
+    *       c.observed_reg.expect(42.U)
+    *     }
+    *   }
+    * }}}
+    *
+    * @param signal
+    *   the signal to be observed
+    * @return
+    *   a signal with the same format to be tested on Top module's spec.
+    */
+  protected def observe[T <: Data](signal: T): T = {
+    val ob = IO(Output(chiselTypeOf(signal)))
+    ob := 0.U.asTypeOf(chiselTypeOf(signal))
+    BoringUtils.bore(signal, Seq(ob))
+    ob
+  }
+}

--- a/src/main/scala/chiseltest/experimental/Observe.scala
+++ b/src/main/scala/chiseltest/experimental/Observe.scala
@@ -16,33 +16,48 @@ trait Observer { this: Module =>
     * Usage:
     *
     * {{{
-    * import chiseltest.experimental.Observer
+    * import chisel3._
     *
-    * // This is the module to be tested
+    * // This is the module and submodule to be tested
     * class SubModule extends Module {
-    *     val reg  = Reg(UInt(6.W))
-    *     reg := 42.U
-    *   }
+    *   val reg  = Reg(UInt(6.W))
+    *   reg := 42.U
+    * }
     *
-    *   // Top module which instantiates the submodule
-    *   class Top extends Module {
-    *     val submodule = Module(new SubModule)
-    *   }
+    * // Top module which instantiates the submodule
+    * class Top extends Module {
+    *   val submodule = Module(new SubModule)
+    * }
     *
-    *   // Here we create a wrapper extending the Top module adding the observer
-    *   class TopWrapper extends Top with Observer {
-    *     val observed_reg  = observe(submodule.reg)
-    *   }
-    *
+    * // Generate the main project Verilog
+    * object Proj extends App {
+    *  (new chisel3.stage.ChiselStage).emitVerilog(
+    *    new Top()
+    *  )}
     * }}}
     *
-    * The `Top` module can be tested with `chiseltest` and `scalatest` like:
+    * Then in your spec, test the `Top` module with `chiseltest` and `scalatest` while being
+    *      able to observe the submodule:
     * {{{
-    *   it should "observe a submodule Reg by using BoringUtils" in {
-    *     test(new TopWrapper) { c =>
-    *       c.observed_reg.expect(42.U)
-    *     }
+    * import chisel3._
+    * import chiseltest._
+    * import org.scalatest._
+    *
+    * import flatspec._
+    * import matchers.should._
+    * import chiseltest.experimental.Observer
+    *
+    * // Here we create a wrapper extending the Top module to add the `Observer` trait
+    * class TopWrapper extends Top with Observer {
+    *   // Observe the submodule "reg" Register
+    *   val observed_reg  = observe(submodule.reg)
+    * }
+    *
+    * it should "observe a submodule Reg by using BoringUtils" in {
+    *   test(new TopWrapper) { c =>
+    *     c.observed_reg.expect(42.U)
     *   }
+    * }
     * }}}
     *
     * @param signal

--- a/src/main/scala/chiseltest/experimental/Observe.scala
+++ b/src/main/scala/chiseltest/experimental/Observe.scala
@@ -43,8 +43,8 @@ object expose {
     *  )}
     * }}}
     *
-    * Then in your spec, test the `Top` module with `chiseltest` and `scalatest` while being
-    *      able to observe the submodule:
+    * Then in your spec, test the `Top` module with `chiseltest` and `scalatest` while exposing the signal from
+    * the submodule to the testbench:
     * {{{
     * import chisel3._
     * import chiseltest._
@@ -60,7 +60,7 @@ object expose {
     *   val exposed_reg  = expose(submodule.reg)
     * }
     *
-    * it should "observe a submodule Reg by using BoringUtils" in {
+    * it should "expose a submodule Reg by using BoringUtils" in {
     *   test(new TopWrapper) { c =>
     *     c.exposed_reg.expect(42.U)
     *   }
@@ -68,7 +68,7 @@ object expose {
     * }}}
     *
     * @param signal
-    *   the signal to be observed
+    *   the signal to be exposed
     * @return
     *   a signal with the same format to be tested on Top module's spec.
     */

--- a/src/test/scala/chiseltest/experimental/tests/ObserveExposeTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/ObserveExposeTest.scala
@@ -11,7 +11,7 @@ import org.scalatest._
 import flatspec._
 import matchers.should._
 
-class ObserverTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+class ObserveExposeTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Expose"
 
   class SubModule extends Module {

--- a/src/test/scala/chiseltest/experimental/tests/ObserveTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/ObserveTest.scala
@@ -2,7 +2,7 @@
 
 package chiseltest.experimental.tests
 
-import chiseltest.experimental.Observer
+import chiseltest.experimental.{expose}
 
 import chisel3._
 import chiseltest._
@@ -12,7 +12,7 @@ import flatspec._
 import matchers.should._
 
 class ObserverTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
-  behavior of "Observer"
+  behavior of "Expose"
 
   class SubModule extends Module {
     val reg  = Reg(UInt(6.W))
@@ -30,29 +30,29 @@ class ObserverTest extends AnyFlatSpec with ChiselScalatestTester with Matchers 
     val submodule = Module(new SubModule)
   }
 
-  class TopWrapper extends Top with Observer {
-    val observed_reg  = observe(submodule.reg)
-    val observed_wire = observe(submodule.wire)
-    val observed_vec  = observe(submodule.vec)
+  class TopWrapper extends Top {
+    val exposed_reg  = expose(submodule.reg)
+    val exposed_wire = expose(submodule.wire)
+    val exposed_vec  = expose(submodule.vec)
   }
 
-  it should "observe a submodule Reg by using BoringUtils" in {
+  it should "expose a submodule Reg by using BoringUtils" in {
     test(new TopWrapper) { c =>
-      c.observed_reg.expect(42.U)
+      c.exposed_reg.expect(42.U)
     }
   }
-  it should "observe a submodule Wire by using BoringUtils" in {
+  it should "expose a submodule Wire by using BoringUtils" in {
     test(new TopWrapper) { c =>
-      c.observed_wire.expect(42.U)
+      c.exposed_wire.expect(42.U)
     }
   }
-  it should "observe a submodule Vector by using BoringUtils" in {
+  it should "expose a submodule Vector by using BoringUtils" in {
     test(new TopWrapper) { c =>
       c.clock.step()
-      c.observed_vec(0).expect(1.S)
-      c.observed_vec(10).expect(10.S)
-      c.observed_vec(20).expect(-25.S)
-      c.observed_vec(31).expect(150.S)
+      c.exposed_vec(0).expect(1.S)
+      c.exposed_vec(10).expect(10.S)
+      c.exposed_vec(20).expect(-25.S)
+      c.exposed_vec(31).expect(150.S)
     }
   }
 }

--- a/src/test/scala/chiseltest/experimental/tests/ObserveTest.scala
+++ b/src/test/scala/chiseltest/experimental/tests/ObserveTest.scala
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiseltest.experimental.tests
+
+import chiseltest.experimental.Observer
+
+import chisel3._
+import chiseltest._
+import org.scalatest._
+
+import flatspec._
+import matchers.should._
+
+class ObserverTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Observer"
+
+  class SubModule extends Module {
+    val reg  = Reg(UInt(6.W))
+    val wire = Wire(UInt(6.W))
+    val vec  = RegInit(VecInit(Seq.fill(32)(0.S(32.W))))
+    reg     := 42.U
+    wire    := reg
+    vec(0)  := 1.S
+    vec(10) := 10.S
+    vec(20) := -25.S
+    vec(31) := 150.S
+  }
+
+  class Top extends Module {
+    val submodule = Module(new SubModule)
+  }
+
+  class TopWrapper extends Top with Observer {
+    val observed_reg  = observe(submodule.reg)
+    val observed_wire = observe(submodule.wire)
+    val observed_vec  = observe(submodule.vec)
+  }
+
+  it should "observe a submodule Reg by using BoringUtils" in {
+    test(new TopWrapper) { c =>
+      c.observed_reg.expect(42.U)
+    }
+  }
+  it should "observe a submodule Wire by using BoringUtils" in {
+    test(new TopWrapper) { c =>
+      c.observed_wire.expect(42.U)
+    }
+  }
+  it should "observe a submodule Vector by using BoringUtils" in {
+    test(new TopWrapper) { c =>
+      c.clock.step()
+      c.observed_vec(0).expect(1.S)
+      c.observed_vec(10).expect(10.S)
+      c.observed_vec(20).expect(-25.S)
+      c.observed_vec(31).expect(150.S)
+    }
+  }
+}

--- a/src/test/scala/chiseltest/formal/examples/DecoupledGCD.scala
+++ b/src/test/scala/chiseltest/formal/examples/DecoupledGCD.scala
@@ -4,6 +4,7 @@ package chiseltest.formal.examples
 import chisel3._
 import chiseltest._
 import chiseltest.formal._
+import chiseltest.experimental._
 import chiseltest.iotesters.DecoupledGcd
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -14,7 +15,7 @@ class FormalGcdSpec extends AnyFlatSpec with ChiselScalatestTester with Formal {
 }
 
 /** check formal properties of the DecoupledGcd implementation */
-class DecoupledGcdSpec(makeDut: => DecoupledGcd) extends Module with Observer {
+class DecoupledGcdSpec(makeDut: => DecoupledGcd) extends Module {
   // create an instance of our DUT and expose its I/O
   val dut = Module(makeDut)
   val input = IO(chiselTypeOf(dut.input))

--- a/src/test/scala/chiseltest/formal/examples/VGBComparisonOfFormalAndSimulation.scala
+++ b/src/test/scala/chiseltest/formal/examples/VGBComparisonOfFormalAndSimulation.scala
@@ -8,6 +8,7 @@ import chisel3.experimental._
 import chisel3.util.experimental.BoringUtils
 import chiseltest._
 import chiseltest.formal._
+import chiseltest.experimental._
 import org.scalatest.flatspec.AnyFlatSpec
 
 /** Chisel port of the "Verification Gentleman" blog post on formal vs. simulation.
@@ -23,7 +24,7 @@ class VGBComparisonOfFormalAndSimulation extends AnyFlatSpec with ChiselScalates
   // TODO: unfortunately we currently do not support cover statements
 }
 
-class ShapeProcessorProps extends Module with Observer {
+class ShapeProcessorProps extends Module {
   import ShapeProcessorModelling._
   import ShapeEnum._
   import OperationEnum._
@@ -157,14 +158,6 @@ class ShapeProcessorProps extends Module with Observer {
   // Check that illegal CTRL writes don't update the SFR fields. This catches all cases of illegal
   // writes under one 'assert', instead of having them spread out over many.
   assert(IfThen(past(io.write && !isLegalCtrlWriteData), stable(sfr)))
-}
-
-trait Observer { this: Module =>
-  protected def observe[T <: Data](signal: T): T = {
-    val wire = WireInit(0.U.asTypeOf(chiselTypeOf(signal)))
-    BoringUtils.bore(signal, Seq(wire))
-    wire
-  }
 }
 
 object ShapeProcessorModelling {


### PR DESCRIPTION
This PR adds the Observer trait that can be used on wrapper modules for looking into submodules on chiseltest.

The wrapper makes sure the observed objects are only created in the object instantiation during the test and not Verilog generation (creating the observed wires).

## Usage

Create a Chisel module that instantiates a submodule as usual:

```scala
import chisel3._

// This is the module and submodule to be tested
class SubModule extends Module {
  val reg  = Reg(UInt(6.W))
  reg := 42.U
}

// Top module which instantiates the submodule
class Top extends Module {
  val submodule = Module(new SubModule)
}

// Generate the main project Verilog
object Proj extends App {
 (new chisel3.stage.ChiselStage).emitVerilog(
   new Top()
)}
```

In the test, wrap the top module adding the `Observer` trait and inside it use the `observe` method pointing to submodule objects. Use this wrapper as the DUT and the observed objects will be available for testing:

```scala
import chisel3._
import chiseltest._
import org.scalatest._

import flatspec._
import matchers.should._
import chiseltest.experimental.Observer

// Here we create a wrapper extending the Top module to add the `Observer` trait
class TopWrapper extends Top with Observer {
  // Observe the submodule "reg" Register
  val observed_reg  = observe(submodule.reg)
}

it should "observe a submodule Reg by using BoringUtils" in {
  test(new TopWrapper) { c =>
    c.observed_reg.expect(42.U)
  }
}
```