### PR TITLE
formal: add softAssert method to solver

### DIFF
--- a/src/main/scala/chiseltest/formal/backends/smt/SMTLibSolver.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/SMTLibSolver.scala
@@ -48,7 +48,13 @@ private class SMTLibSolverContext(cmd: List[String], val solver: Solver) extends
     _stackDepth -= 1
   }
   override def assert(expr: BVExpr): Unit = {
+    require(expr.width == 1, s"$expr is not a boolean")
     writeCommand(s"(assert ${serialize(expr)})")
+  }
+  override def softAssert(expr: BVExpr, weight: Int): Unit = {
+    require(weight >= 0, "weight should be non-negative")
+    require(expr.width == 1, s"$expr is not a boolean")
+    writeCommand(s"(assert-soft ${serialize(expr)} :weight $weight)")
   }
   override def queryModel(e: BVSymbol): Option[BigInt] = getValue(e)
   override def getValue(e: BVExpr): Option[BigInt] = {

--- a/src/main/scala/chiseltest/formal/backends/smt/Solver.scala
+++ b/src/main/scala/chiseltest/formal/backends/smt/Solver.scala
@@ -32,7 +32,8 @@ private[chiseltest] trait SolverContext {
   def stackDepth: Int // returns the size of the push/pop stack
   def push():     Unit
   def pop():      Unit
-  def assert(expr: BVExpr): Unit
+  def assert(expr:     BVExpr): Unit
+  def softAssert(expr: BVExpr, weight: Int = 1): Unit
   final def check(produceModel: Boolean): SolverResult = {
     require(pLogic.isDefined, "Use `setLogic` to select the logic.")
     pCheckCount += 1


### PR DESCRIPTION
This is in preparation of a constrained random implementation.

@vighneshiyer and I are working on the actual sampler out of tree, but we need this method in `chiseltest` so that we can re-use the SMT solver bindings.