### PR TITLE
formal: run firrtl optimizations before generating STMLib

### DIFF
--- a/src/main/scala/chiseltest/formal/Formal.scala
+++ b/src/main/scala/chiseltest/formal/Formal.scala
@@ -38,6 +38,12 @@ trait Formal { this: HasTestName =>
 /** An _escape hatch_ to disable more pessimistic modelling of undefined values. */
 case object DoNotModelUndef extends NoTargetAnnotation
 
+/** Disables firrtl optimizations when converting to a SMT/Btor2 system.
+  * This is an escape hatch in case you suspect optimizations of doing something wrong!
+  * Normally this annotation should *not* be needed!
+  */
+case object DoNotOptimizeFormal extends NoTargetAnnotation
+
 private object Formal {
   def verify[T <: Module](dutGen: => T, annos: AnnotationSeq): Unit = {
     val ops = getOps(annos)


### PR DESCRIPTION
For the examples that we have in the repo, the SMT solving isn't really getting any faster, but the SMT files we generate are somewhat smaller. For a bigger example (ShapeProcessorProps.smt2) it goes from 114K to 57K.

This PR also adds an escape hatch annotation in case the optimizations turn out not to be a good idea, but I think they should be on by default.