### PR TITLE
formal: if there are no asserts, the verification needs to pass

### DIFF
--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -34,11 +34,20 @@ private[chiseltest] object Maltese {
   def bmc(circuit: ir.Circuit, annos: AnnotationSeq, kMax: Int, resetLength: Int = 0): Unit = {
     require(kMax > 0)
     require(resetLength >= 0)
+
+    // convert to transition system
     val targetDir = Compiler.requireTargetDir(annos)
     val modelUndef = !annos.contains(DoNotModelUndef)
     val sysAnnos: AnnotationSeq = if (modelUndef) { DefRandomAnnos ++: annos }
     else { annos }
     val sysInfo = toTransitionSystem(circuit, sysAnnos)
+
+    // if the system has no bad states => success!
+    if (noBadStates(sysInfo.sys)) {
+      return // proven correct by the compiler!
+    }
+
+    // perform check
     val checkers = makeCheckers(annos)
     assert(checkers.size == 1, "Parallel checking not supported atm!")
     checkers.head.check(sysInfo.sys, kMax = kMax + resetLength) match {
@@ -105,6 +114,9 @@ private[chiseltest] object Maltese {
 
     SysInfo(sys, stateMap, memDepths)
   }
+
+  private def noBadStates(sys: TransitionSystem): Boolean =
+    sys.signals.count(_.lbl == IsBad) == 0
 
   private def firrtlStage = new FirrtlStage
 

--- a/src/test/scala/chiseltest/formal/BasicBoundedCheckTests.scala
+++ b/src/test/scala/chiseltest/formal/BasicBoundedCheckTests.scala
@@ -10,6 +10,10 @@ import chisel3._
 class BasicBoundedCheckTests extends AnyFlatSpec with ChiselScalatestTester with Formal {
   behavior of "verify command"
 
+  it should "support modules that do not have any asserts (trivial pass!)"  taggedAs FormalTag in {
+    verify(new AdderWithoutAsserts, Seq(BoundedCheck(1)))
+  }
+
   it should "support simple bmc with a passing check" taggedAs FormalTag in {
     // this one should pass since we only check one step
     verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 1)))
@@ -49,6 +53,13 @@ class BasicBoundedCheckTests extends AnyFlatSpec with ChiselScalatestTester with
       RawTester.verify(new FailAfterModule(2), Seq(BoundedCheck(kMax = 2)))
     }
   }
+}
+
+class AdderWithoutAsserts extends Module {
+  val a = IO(Input(UInt(8.W)))
+  val b = IO(Input(UInt(8.W)))
+  val r = IO(Output(UInt(8.W)))
+  r := a + b
 }
 
 class AssumeAssertTestModule extends Module {


### PR DESCRIPTION
Previously it was running into an assertion violation.