### PR TITLE
Implements Hardware testing allowing test suite to detect exceptions

### DIFF
--- a/src/main/scala/chiseltest/ChiselScalatestTester.scala
+++ b/src/main/scala/chiseltest/ChiselScalatestTester.scala
@@ -65,6 +65,14 @@ trait ChiselScalatestTester extends Assertions with TestSuiteMixin with TestEnvI
     def runUntilAssertFail(timeout: Int = 1000): TestResult = {
       new TestResult(HardwareTesterBackend.run(dutGen, finalAnnos, timeout = timeout, expectFail = true))
     }
+
+    /** Resets and then executes the circuit until a timeout or a stop or assertion failure.
+      * Throws an exception if the timeout is reached or a normal stop is encountered.
+      * @param timeout number of cycles after which to timeout; set to 0 for no timeout
+      */
+    def runReturningExceptions(timeout: Int = 1000): TestResult = {
+      new TestResult(HardwareTesterBackend.runReturningExceptions(dutGen, finalAnnos, timeout = timeout))
+    }
   }
 
   // Provide test fixture data as part of 'global' context during test runs

--- a/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/TreadleSimulator.scala
@@ -67,18 +67,14 @@ private class TreadleContext(tester: TreadleTester, toplevel: TopmoduleInfo) ext
       case Some(_) =>
       case None    => throw NoClockException(tester.topName)
     }
-    var delta: Int = 0
     try {
-      (0 until n).foreach { _ =>
-        delta += 1
-        tester.step()
-      }
+      tester.step(n)
       StepOk
     } catch {
       case s: StopException =>
         val infos = s.stops.map(_.name)
         val isFailure = s.stops.exists(_.ret > 0)
-        StepInterrupted(delta, isFailure, infos)
+        StepInterrupted(tester.cycleCount.toInt, isFailure, infos)
     }
   }
 


### PR DESCRIPTION
- Create new low level `runReturningExceptions` that can return `ChiselAssertionError`s
- Optimize step calling by using step parameter and tester.cycleCount
- Add `runReturningExceptions` to `ChiselScalatestTester`
- Add tests for new function with emphasis on precedence of simultaneous outcomes
- Fix to scaladoc Unknown tag
- Called step without specifying default argument