### PR TITLE
Fix Verilator on Mac

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Verilator
         run: |
-          brew install verilator
+          brew extract --version=4.200 verilator homebrew/cask
+          brew install verilator@4.200
           verilator --version
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10


### PR DESCRIPTION
CI is failing for Verilator for Mac. There were recent changes to Verilator that make it no longer work with Mac/BSD ar (see https://github.com/verilator/verilator/issues/2999).

This fixes the issue by installing an older version of Verilator via Homebrew.

It's unfortunately a little slow because it builds from source. We badly need to fix CI, we can speed it up in a follow on PR.