### PR TITLE
Use FirrtlPhase instead of FirrtlStage in Maltese

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Verilator
         run: |
-          brew install verilator
+          brew extract --version=4.200 verilator homebrew/cask
+          brew install verilator@4.200
           verilator --version
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10


### PR DESCRIPTION
This avoids file serialization which results in "Multiple
CustomFileEmission annotations would be serialized to the same file"
exceptions sometimes.

I believe this is a real bug that used to be hidden but was exposed by https://github.com/chipsalliance/firrtl/pull/2393.
That being said, the error is annoying so at least for 3.5 I'm going to change file emission to only warn if the colliding contents are identical.

This PR also fixes the Verilator CI tests on MacOS.
The issue is fixed by installing an older version of Verilator via Homebrew.

It's unfortunately a little slow because it builds from source. We badly need to fix CI, we can speed it up in a follow on PR.