### PR TITLE
formal: fix replay for DefRandom nodes inside of submodules

### DIFF
--- a/src/main/scala/chiseltest/formal/backends/FlattenPass.scala
+++ b/src/main/scala/chiseltest/formal/backends/FlattenPass.scala
@@ -9,6 +9,7 @@ import firrtl.options.Dependency
 import firrtl.passes.InlineAnnotation
 import firrtl.stage.Forms
 import firrtl._
+import firrtl.backends.experimental.smt.random.DefRandom
 
 private case class DoNotInlineAnnotation(target: ModuleTarget) extends SingleTargetAnnotation[ModuleTarget] {
   override def duplicate(n: ModuleTarget) = copy(target = n)
@@ -94,10 +95,11 @@ private object FlattenPass extends Transform with DependencyAPIMigration {
   }
 
   private def findStates(m: IsModule, s: ir.Statement): Seq[StateAnnotation] = s match {
-    case reg: ir.DefRegister   => List(StateAnnotation(m.ref(reg.name), reg.tpe))
-    case mem: ir.DefMemory     => List(StateAnnotation(m.ref(mem.name), mem.dataType, mem.depth))
-    case b:   ir.Block         => b.stmts.flatMap(findStates(m, _))
-    case _:   ir.Conditionally => throw new RuntimeException("Not low form!")
+    case reg:  ir.DefRegister   => List(StateAnnotation(m.ref(reg.name), reg.tpe))
+    case rand: DefRandom        => List(StateAnnotation(m.ref(rand.name), rand.tpe))
+    case mem:  ir.DefMemory     => List(StateAnnotation(m.ref(mem.name), mem.dataType, mem.depth))
+    case b:    ir.Block         => b.stmts.flatMap(findStates(m, _))
+    case _:    ir.Conditionally => throw new RuntimeException("Not low form!")
     case _ => List()
   }
 

--- a/src/main/scala/chiseltest/formal/backends/Maltese.scala
+++ b/src/main/scala/chiseltest/formal/backends/Maltese.scala
@@ -156,8 +156,18 @@ private[chiseltest] object Maltese {
   }
 
   private def witnessToTrace(sysInfo: SysInfo, w: Witness): Trace = {
-    val inputNames = sysInfo.sys.inputs.map(_.name).toIndexedSeq
-    val stateNames = sysInfo.sys.states.map(_.name).map(sysInfo.stateMap).toIndexedSeq
+    val inputNames = sysInfo.sys.inputs
+      .map(_.name)
+      // DefRand nodes are modelled as inputs for the formal engine,
+      // but will be turned into registers for the replay on treadle
+      // thus we need to translate them to a non-flattened path
+      .map(name => sysInfo.stateMap.getOrElse(name, name))
+      .toIndexedSeq
+    val stateNames = sysInfo.sys.states
+      .map(_.name)
+      // translate flattened state name to hierarchical path
+      .map(sysInfo.stateMap)
+      .toIndexedSeq
 
     Trace(
       inputs = w.inputs.map(_.toSeq.map { case (i, value) => inputNames(i) -> value }),

--- a/src/test/scala/chiseltest/formal/UndefinedValuesTests.scala
+++ b/src/test/scala/chiseltest/formal/UndefinedValuesTests.scala
@@ -40,6 +40,18 @@ class UndefinedValuesTests extends AnyFlatSpec with ChiselScalatestTester with F
     // WARN: it is not recommended to turn of undef modelling and it is not guaranteed that this test won't break
     verify(new InvalidSignalIs(0), Seq(BoundedCheck(2), DoNotModelUndef, DefaultBackend))
   }
+
+  "invalid signal" should "fail correctly even when it is in a submodule" taggedAs FormalTag in {
+    // this is a regression test for a bug where we failed to replay failures when the
+    // random (i.e. arbitrary value) signal was in a submodule
+    val e = intercept[FailedBoundedCheckException] {
+      verify(new Module {
+        val inst = Module(new InvalidSignalIs(0))
+      }, Seq(BoundedCheck(1), DefaultBackend))
+    }
+    assert(e.failAt == 0)
+  }
+
 }
 
 class DivisionByZeroIsEq(to: Int) extends Module {


### PR DESCRIPTION
A translation step was missing. This addresses: https://github.com/ucb-bar/chisel-testers2/issues/460