### PR TITLE
Support FSDB (Verdi) waveform dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 .bloop/
 .metals/
 .vscode/
+
+# Synopsys Verdi
+novas_dump.log
+ucli.key

--- a/src/main/scala/chiseltest/package.scala
+++ b/src/main/scala/chiseltest/package.scala
@@ -329,6 +329,7 @@ package object chiseltest {
   val IcarusBackendAnnotation = simulator.IcarusBackendAnnotation
   val WriteVcdAnnotation = simulator.WriteVcdAnnotation
   val WriteVpdAnnotation = simulator.WriteVpdAnnotation
+  val WriteFsdbAnnotation = simulator.WriteFsdbAnnotation
   val WriteLxtAnnotation = simulator.WriteLxtAnnotation
   type WriteLxtAnnotation = simulator.WriteLxtAnnotation
   val WriteFstAnnotation = simulator.WriteFstAnnotation

--- a/src/main/scala/chiseltest/simulator/Simulator.scala
+++ b/src/main/scala/chiseltest/simulator/Simulator.scala
@@ -118,6 +118,10 @@ case object WriteVpdAnnotation extends WriteWaveformAnnotation {
   override def format: String = "vpd"
 }
 
+case object WriteFsdbAnnotation extends WriteWaveformAnnotation {
+  override def format: String = "fsdb"
+}
+
 case class PlusArgsAnnotation(plusArgs: Seq[String]) extends NoTargetAnnotation
 
 /** enables more verbose print outs from the simulator creation and execution

--- a/src/main/scala/chiseltest/simulator/VcsSimulator.scala
+++ b/src/main/scala/chiseltest/simulator/VcsSimulator.scala
@@ -136,12 +136,12 @@ private object VcsSimulator extends Simulator {
     val verdiFlags = annos.collectFirst{ case WriteFsdbAnnotation =>
       // Check whether VERDI_HOME is defined in system environment
       sys.env.get("VERDI_HOME") match {
-        case Some(verdi_home) =>
+        case Some(verdiHome) =>
           Seq(
             "-kdb",
             "-P",
-            s"$verdi_home/share/PLI/VCS/LINUX64/novas.tab",
-            s"$verdi_home/share/PLI/VCS/LINUX64/pli.a"
+            s"$verdiHome/share/PLI/VCS/LINUX64/novas.tab",
+            s"$verdiHome/share/PLI/VCS/LINUX64/pli.a"
           )
         case None => require(requirement = false,
           s"FSDB waveform dump depends on VERDI_HOME, please set the system environment");Seq.empty

--- a/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
@@ -9,7 +9,8 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
   def codeGen(
     toplevel:    TopmoduleInfo,
     moduleNames: Seq[String],
-    useVpdDump:  Boolean = false
+    useVpdDump:  Boolean = false,
+    useFsdbDump: Boolean = false,
   ): String = {
     val testbenchName = firrtl.Namespace(moduleNames).newName("testbench")
 
@@ -49,11 +50,21 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
     codeBuffer.append(s"    $$init_outs(${outputNames.mkString(", ")});\n")
     codeBuffer.append(s"    $$init_sigs($dutName);\n")
 
+    /* Dump VPD Waveform File*/
     if (useVpdDump) {
       codeBuffer.append("    /*** Enable VPD dump ***/\n")
       codeBuffer.append("    if ($value$plusargs(\"vcdplusfile=%s\", " + dumpFileVar + ")) begin\n")
       codeBuffer.append(s"      $$vcdplusfile($dumpFileVar);\n")
       codeBuffer.append(s"      $$vcdpluson;\n")
+      codeBuffer.append("    end\n")
+    }
+
+    /* Dump FSDB Waveform File*/
+    if(useFsdbDump){
+      codeBuffer.append("    /*** Enable FSDB dump ***/\n")
+      codeBuffer.append("    if ($value$plusargs(\"fsdbfile=%s\", " + dumpFileVar + ")) begin\n")
+      codeBuffer.append(s"      $$fsdbDumpfile($dumpFileVar);\n")
+      codeBuffer.append(s"      $$fsdbDumpvars(0, $dutName);\n")
       codeBuffer.append("    end\n")
     }
 

--- a/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
+++ b/src/main/scala/chiseltest/simulator/ipc/VpiVerilogHarnessGenerator.scala
@@ -10,7 +10,7 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
     toplevel:    TopmoduleInfo,
     moduleNames: Seq[String],
     useVpdDump:  Boolean = false,
-    useFsdbDump: Boolean = false,
+    useFsdbDump: Boolean = false
   ): String = {
     val testbenchName = firrtl.Namespace(moduleNames).newName("testbench")
 
@@ -60,7 +60,7 @@ private[chiseltest] object VpiVerilogHarnessGenerator {
     }
 
     /* Dump FSDB Waveform File*/
-    if(useFsdbDump){
+    if (useFsdbDump) {
       codeBuffer.append("    /*** Enable FSDB dump ***/\n")
       codeBuffer.append("    if ($value$plusargs(\"fsdbfile=%s\", " + dumpFileVar + ")) begin\n")
       codeBuffer.append(s"      $$fsdbDumpfile($dumpFileVar);\n")

--- a/src/test/scala/chiseltest/simulator/WaveformCompliance.scala
+++ b/src/test/scala/chiseltest/simulator/WaveformCompliance.scala
@@ -35,7 +35,7 @@ abstract class WaveformCompliance(sim: Simulator, tag: Tag = DefaultTag) extends
       |    io.out <= c.io.out
       |""".stripMargin
 
-  val waveformExtensions = Set("vcd", "txt", "fst", "vpd", "lxt", "lxt2")
+  val waveformExtensions = Set("vcd", "txt", "fst", "vpd", "lxt", "lxt2", "fsdb")
   it should "not create a waveform file when no WriteWaveformAnnotation is provided" taggedAs(tag) in {
     performDutTest(Seq())
     val dumps = testDirFiles().filter(f => waveformExtensions.contains(f.last.split('.').last))
@@ -91,6 +91,10 @@ abstract class WaveformCompliance(sim: Simulator, tag: Tag = DefaultTag) extends
       case "vpd" =>
         val txt = os.read(file).toString.take(3)
         assert(txt.startsWith("xV4"))
+      case "fsdb" =>
+        val txt = os.read(file)
+        assert(txt.contains("FSDB Writer"))
+        assert(txt.contains("finish"))
       case other => throw new NotImplementedError(s"TODO: add code to check $other")
     }
   }


### PR DESCRIPTION
I added support for dumping FSDB waveform used by Synopsys Verdi

Local test passed: `sbt "testOnly chiseltest.simulator.VcsWaveformCompliance"`
gcc version: `gcc version 8.5.0 20210514 (Red Hat 8.5.0-4) (GCC)`
vcs version: `VCS S-2021.09-SP1`
verdi version: `S-2021.09-SP1`